### PR TITLE
geom_alt props

### DIFF
--- a/data/101/911/679/101911679.geojson
+++ b/data/101/911/679/101911679.geojson
@@ -249,6 +249,9 @@
         "qs_pg:id":1077601
     },
     "wof:country":"AL",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7bfb3732799a12eb59c116b57aa14995",
     "wof:hierarchy":[
         {
@@ -260,7 +263,7 @@
         }
     ],
     "wof:id":101911679,
-    "wof:lastmodified":1566584928,
+    "wof:lastmodified":1582318804,
     "wof:name":"Ersek\u00eb",
     "wof:parent_id":421193597,
     "wof:placetype":"locality",

--- a/data/421/167/927/421167927.geojson
+++ b/data/421/167/927/421167927.geojson
@@ -242,6 +242,9 @@
     },
     "wof:country":"AL",
     "wof:created":1459008748,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bc3cc841e5df0d43854a53aa58e6f38a",
     "wof:hierarchy":[
         {
@@ -252,7 +255,7 @@
         }
     ],
     "wof:id":421167927,
-    "wof:lastmodified":1566584945,
+    "wof:lastmodified":1582318805,
     "wof:name":"Shkod\u00ebr",
     "wof:parent_id":85667793,
     "wof:placetype":"county",

--- a/data/421/168/061/421168061.geojson
+++ b/data/421/168/061/421168061.geojson
@@ -209,6 +209,9 @@
     },
     "wof:country":"AL",
     "wof:created":1459008752,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9ba38c173bab0ed000b47b05bb4d718c",
     "wof:hierarchy":[
         {
@@ -219,7 +222,7 @@
         }
     ],
     "wof:id":421168061,
-    "wof:lastmodified":1566584942,
+    "wof:lastmodified":1582318804,
     "wof:name":"Has",
     "wof:parent_id":85667797,
     "wof:placetype":"county",

--- a/data/421/169/685/421169685.geojson
+++ b/data/421/169/685/421169685.geojson
@@ -266,6 +266,9 @@
     },
     "wof:country":"AL",
     "wof:created":1459008820,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d738058082a784b414bc6d1b4fbfeb2f",
     "wof:hierarchy":[
         {
@@ -276,7 +279,7 @@
         }
     ],
     "wof:id":421169685,
-    "wof:lastmodified":1566584945,
+    "wof:lastmodified":1582318805,
     "wof:name":"Dib\u00ebr",
     "wof:parent_id":85667821,
     "wof:placetype":"county",

--- a/data/421/169/921/421169921.geojson
+++ b/data/421/169/921/421169921.geojson
@@ -260,6 +260,9 @@
     },
     "wof:country":"AL",
     "wof:created":1459008829,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"35cd861eb1301cafb6aad19e99ebafaa",
     "wof:hierarchy":[
         {
@@ -270,7 +273,7 @@
         }
     ],
     "wof:id":421169921,
-    "wof:lastmodified":1566584946,
+    "wof:lastmodified":1582318805,
     "wof:name":"Lezh\u00eb",
     "wof:parent_id":85667829,
     "wof:placetype":"county",

--- a/data/421/178/941/421178941.geojson
+++ b/data/421/178/941/421178941.geojson
@@ -285,6 +285,9 @@
     },
     "wof:country":"AL",
     "wof:created":1459009198,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"46fd2707f919d612e91a060834f796a0",
     "wof:hierarchy":[
         {
@@ -295,7 +298,7 @@
         }
     ],
     "wof:id":421178941,
-    "wof:lastmodified":1566584956,
+    "wof:lastmodified":1582318807,
     "wof:name":"Pogradec",
     "wof:parent_id":85667807,
     "wof:placetype":"county",

--- a/data/421/179/955/421179955.geojson
+++ b/data/421/179/955/421179955.geojson
@@ -374,6 +374,9 @@
     },
     "wof:country":"AL",
     "wof:created":1459009239,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3b23a61fb8d50d62a934d3b9adf43389",
     "wof:hierarchy":[
         {
@@ -384,7 +387,7 @@
         }
     ],
     "wof:id":421179955,
-    "wof:lastmodified":1566584955,
+    "wof:lastmodified":1582318806,
     "wof:name":"Sarand\u00eb",
     "wof:parent_id":85667801,
     "wof:placetype":"county",

--- a/data/421/181/321/421181321.geojson
+++ b/data/421/181/321/421181321.geojson
@@ -215,6 +215,9 @@
     },
     "wof:country":"AL",
     "wof:created":1459009292,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"15f50b4e1792b641a12fe97b872f22c2",
     "wof:hierarchy":[
         {
@@ -225,7 +228,7 @@
         }
     ],
     "wof:id":421181321,
-    "wof:lastmodified":1566584952,
+    "wof:lastmodified":1582318806,
     "wof:name":"Kurbin",
     "wof:parent_id":85667829,
     "wof:placetype":"county",

--- a/data/421/182/353/421182353.geojson
+++ b/data/421/182/353/421182353.geojson
@@ -218,6 +218,9 @@
     },
     "wof:country":"AL",
     "wof:created":1459009327,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f01c04ef58a0d556b79ba3cd410d858a",
     "wof:hierarchy":[
         {
@@ -228,7 +231,7 @@
         }
     ],
     "wof:id":421182353,
-    "wof:lastmodified":1566584956,
+    "wof:lastmodified":1582318807,
     "wof:name":"Tiran\u00eb",
     "wof:parent_id":1108803089,
     "wof:placetype":"county",

--- a/data/421/184/327/421184327.geojson
+++ b/data/421/184/327/421184327.geojson
@@ -221,6 +221,9 @@
     },
     "wof:country":"AL",
     "wof:created":1459009407,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"326824ae134f3296a6b3c78a28596ab1",
     "wof:hierarchy":[
         {
@@ -231,7 +234,7 @@
         }
     ],
     "wof:id":421184327,
-    "wof:lastmodified":1566584955,
+    "wof:lastmodified":1582318806,
     "wof:name":"Delvin\u00eb",
     "wof:parent_id":85667801,
     "wof:placetype":"county",

--- a/data/421/184/543/421184543.geojson
+++ b/data/421/184/543/421184543.geojson
@@ -215,6 +215,9 @@
     },
     "wof:country":"AL",
     "wof:created":1459009414,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ab4dec08b7626f1694e99be16decd402",
     "wof:hierarchy":[
         {
@@ -225,7 +228,7 @@
         }
     ],
     "wof:id":421184543,
-    "wof:lastmodified":1566584955,
+    "wof:lastmodified":1582318806,
     "wof:name":"Lushnje",
     "wof:parent_id":85667789,
     "wof:placetype":"county",

--- a/data/421/185/415/421185415.geojson
+++ b/data/421/185/415/421185415.geojson
@@ -224,6 +224,9 @@
     },
     "wof:country":"AL",
     "wof:created":1459009442,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4f7077909ce51321d2ea8fcaa6c2ea97",
     "wof:hierarchy":[
         {
@@ -234,7 +237,7 @@
         }
     ],
     "wof:id":421185415,
-    "wof:lastmodified":1566584957,
+    "wof:lastmodified":1582318807,
     "wof:name":"Elbasan",
     "wof:parent_id":85667815,
     "wof:placetype":"county",

--- a/data/421/185/973/421185973.geojson
+++ b/data/421/185/973/421185973.geojson
@@ -238,6 +238,9 @@
     },
     "wof:country":"AL",
     "wof:created":1459009460,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"505fe1777805e4f0cf38886a66da7c40",
     "wof:hierarchy":[
         {
@@ -249,7 +252,7 @@
         }
     ],
     "wof:id":421185973,
-    "wof:lastmodified":1566584957,
+    "wof:lastmodified":1582318807,
     "wof:name":"Lushnj\u00eb",
     "wof:parent_id":421184543,
     "wof:placetype":"locality",

--- a/data/421/186/339/421186339.geojson
+++ b/data/421/186/339/421186339.geojson
@@ -257,6 +257,9 @@
     },
     "wof:country":"AL",
     "wof:created":1459009477,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cc8ac5ebdfad71614b5066add2338d78",
     "wof:hierarchy":[
         {
@@ -267,7 +270,7 @@
         }
     ],
     "wof:id":421186339,
-    "wof:lastmodified":1566584951,
+    "wof:lastmodified":1582318806,
     "wof:name":"Kuk\u00ebs",
     "wof:parent_id":85667797,
     "wof:placetype":"county",

--- a/data/421/186/997/421186997.geojson
+++ b/data/421/186/997/421186997.geojson
@@ -264,6 +264,9 @@
     },
     "wof:country":"AL",
     "wof:created":1459009498,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"74060e44ead3039e857ffb15ed4cf81c",
     "wof:hierarchy":[
         {
@@ -275,7 +278,7 @@
         }
     ],
     "wof:id":421186997,
-    "wof:lastmodified":1566584951,
+    "wof:lastmodified":1582318806,
     "wof:name":"Bajram Curri",
     "wof:parent_id":421200781,
     "wof:placetype":"locality",

--- a/data/421/187/003/421187003.geojson
+++ b/data/421/187/003/421187003.geojson
@@ -418,6 +418,9 @@
     },
     "wof:country":"AL",
     "wof:created":1459009498,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1cd5239a805597e1c0a265b11b28f780",
     "wof:hierarchy":[
         {
@@ -429,7 +432,7 @@
         }
     ],
     "wof:id":421187003,
-    "wof:lastmodified":1566584950,
+    "wof:lastmodified":1582318805,
     "wof:name":"Durr\u00ebs",
     "wof:parent_id":421187433,
     "wof:placetype":"locality",

--- a/data/421/187/007/421187007.geojson
+++ b/data/421/187/007/421187007.geojson
@@ -408,6 +408,9 @@
     },
     "wof:country":"AL",
     "wof:created":1459009498,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e7c86f65136789ccce16f96a87cf3542",
     "wof:hierarchy":[
         {
@@ -419,7 +422,7 @@
         }
     ],
     "wof:id":421187007,
-    "wof:lastmodified":1566584948,
+    "wof:lastmodified":1582318805,
     "wof:name":"Gjirokast\u00ebr",
     "wof:parent_id":421187729,
     "wof:placetype":"locality",

--- a/data/421/187/009/421187009.geojson
+++ b/data/421/187/009/421187009.geojson
@@ -181,6 +181,9 @@
     },
     "wof:country":"AL",
     "wof:created":1459009498,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"de2e50e3523be312f91c0c773763c9cd",
     "wof:hierarchy":[
         {
@@ -192,7 +195,7 @@
         }
     ],
     "wof:id":421187009,
-    "wof:lastmodified":1566584948,
+    "wof:lastmodified":1582318805,
     "wof:name":"Himar\u00eb",
     "wof:parent_id":1108720861,
     "wof:placetype":"locality",

--- a/data/421/187/037/421187037.geojson
+++ b/data/421/187/037/421187037.geojson
@@ -713,6 +713,9 @@
     },
     "wof:country":"AL",
     "wof:created":1459009499,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"aef487ce9a2e6709ad0f165db36e38a8",
     "wof:hierarchy":[
         {
@@ -724,7 +727,7 @@
         }
     ],
     "wof:id":421187037,
-    "wof:lastmodified":1566584948,
+    "wof:lastmodified":1582318805,
     "wof:name":"Tirana",
     "wof:parent_id":85667831,
     "wof:placetype":"locality",

--- a/data/421/187/039/421187039.geojson
+++ b/data/421/187/039/421187039.geojson
@@ -318,6 +318,9 @@
     },
     "wof:country":"AL",
     "wof:created":1459009499,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8b7f9239b9f3032413012a11076c9ca2",
     "wof:hierarchy":[
         {
@@ -329,7 +332,7 @@
         }
     ],
     "wof:id":421187039,
-    "wof:lastmodified":1566584949,
+    "wof:lastmodified":1582318805,
     "wof:name":"Vlor\u00eb",
     "wof:parent_id":421193353,
     "wof:placetype":"locality",

--- a/data/421/187/431/421187431.geojson
+++ b/data/421/187/431/421187431.geojson
@@ -242,6 +242,9 @@
     },
     "wof:country":"AL",
     "wof:created":1459009513,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b669c5c5fa902f90334a5243e434bb89",
     "wof:hierarchy":[
         {
@@ -252,7 +255,7 @@
         }
     ],
     "wof:id":421187431,
-    "wof:lastmodified":1566584948,
+    "wof:lastmodified":1582318805,
     "wof:name":"Kruj\u00eb",
     "wof:parent_id":85667783,
     "wof:placetype":"county",

--- a/data/421/187/433/421187433.geojson
+++ b/data/421/187/433/421187433.geojson
@@ -263,6 +263,9 @@
     },
     "wof:country":"AL",
     "wof:created":1459009513,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ea35978cd6226c71958f814e6826de9e",
     "wof:hierarchy":[
         {
@@ -273,7 +276,7 @@
         }
     ],
     "wof:id":421187433,
-    "wof:lastmodified":1566584950,
+    "wof:lastmodified":1582318805,
     "wof:name":"Durr\u00ebs",
     "wof:parent_id":85667783,
     "wof:placetype":"county",

--- a/data/421/187/447/421187447.geojson
+++ b/data/421/187/447/421187447.geojson
@@ -227,6 +227,9 @@
     },
     "wof:country":"AL",
     "wof:created":1459009513,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"14f924a277d2718f36d5110a18475069",
     "wof:hierarchy":[
         {
@@ -237,7 +240,7 @@
         }
     ],
     "wof:id":421187447,
-    "wof:lastmodified":1566584947,
+    "wof:lastmodified":1582318805,
     "wof:name":"Kavaj\u00eb",
     "wof:parent_id":1108803089,
     "wof:placetype":"county",

--- a/data/421/187/685/421187685.geojson
+++ b/data/421/187/685/421187685.geojson
@@ -227,6 +227,9 @@
     },
     "wof:country":"AL",
     "wof:created":1459009521,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fcddea873010c9566d58acc96736003d",
     "wof:hierarchy":[
         {
@@ -237,7 +240,7 @@
         }
     ],
     "wof:id":421187685,
-    "wof:lastmodified":1566584949,
+    "wof:lastmodified":1582318805,
     "wof:name":"Berat",
     "wof:parent_id":85667811,
     "wof:placetype":"county",

--- a/data/421/187/687/421187687.geojson
+++ b/data/421/187/687/421187687.geojson
@@ -212,6 +212,9 @@
     },
     "wof:country":"AL",
     "wof:created":1459009521,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1260cae978766cbcf816e12b99398f64",
     "wof:hierarchy":[
         {
@@ -222,7 +225,7 @@
         }
     ],
     "wof:id":421187687,
-    "wof:lastmodified":1566584948,
+    "wof:lastmodified":1582318805,
     "wof:name":"Fier",
     "wof:parent_id":85667789,
     "wof:placetype":"county",

--- a/data/421/187/729/421187729.geojson
+++ b/data/421/187/729/421187729.geojson
@@ -221,6 +221,9 @@
     },
     "wof:country":"AL",
     "wof:created":1459009522,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a1a5ed3e449a4e13450a0b9c969f6a80",
     "wof:hierarchy":[
         {
@@ -231,7 +234,7 @@
         }
     ],
     "wof:id":421187729,
-    "wof:lastmodified":1566584951,
+    "wof:lastmodified":1582318806,
     "wof:name":"Gjirokast\u00ebr",
     "wof:parent_id":85667819,
     "wof:placetype":"county",

--- a/data/421/188/337/421188337.geojson
+++ b/data/421/188/337/421188337.geojson
@@ -224,6 +224,9 @@
     },
     "wof:country":"AL",
     "wof:created":1459009542,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7cf5646c18ea7494a9a5129671f48e7c",
     "wof:hierarchy":[
         {
@@ -234,7 +237,7 @@
         }
     ],
     "wof:id":421188337,
-    "wof:lastmodified":1566584951,
+    "wof:lastmodified":1582318806,
     "wof:name":"Mirdit\u00eb",
     "wof:parent_id":85667829,
     "wof:placetype":"county",

--- a/data/421/189/559/421189559.geojson
+++ b/data/421/189/559/421189559.geojson
@@ -218,6 +218,9 @@
     },
     "wof:country":"AL",
     "wof:created":1459009628,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f73ccf6c9fe1bd02fe8f8d41dd1e1d6a",
     "wof:hierarchy":[
         {
@@ -228,7 +231,7 @@
         }
     ],
     "wof:id":421189559,
-    "wof:lastmodified":1566584951,
+    "wof:lastmodified":1582318806,
     "wof:name":"Tepelen\u00eb",
     "wof:parent_id":85667819,
     "wof:placetype":"county",

--- a/data/421/190/783/421190783.geojson
+++ b/data/421/190/783/421190783.geojson
@@ -240,6 +240,9 @@
     },
     "wof:country":"AL",
     "wof:created":1459009669,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"974ec8a4d971ca60119d128e401472ef",
     "wof:hierarchy":[
         {
@@ -250,7 +253,7 @@
         }
     ],
     "wof:id":421190783,
-    "wof:lastmodified":1566584953,
+    "wof:lastmodified":1582318806,
     "wof:name":"Kor\u00e7\u00eb",
     "wof:parent_id":85667807,
     "wof:placetype":"county",

--- a/data/421/190/851/421190851.geojson
+++ b/data/421/190/851/421190851.geojson
@@ -236,6 +236,9 @@
     },
     "wof:country":"AL",
     "wof:created":1459009671,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9518ccf26b38d46aeda4b1302b1b9bd0",
     "wof:hierarchy":[
         {
@@ -246,7 +249,7 @@
         }
     ],
     "wof:id":421190851,
-    "wof:lastmodified":1566584953,
+    "wof:lastmodified":1582318806,
     "wof:name":"Bulqiz\u00eb",
     "wof:parent_id":85667821,
     "wof:placetype":"county",

--- a/data/421/191/637/421191637.geojson
+++ b/data/421/191/637/421191637.geojson
@@ -215,6 +215,9 @@
     },
     "wof:country":"AL",
     "wof:created":1459009699,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5ebb76da9f356147a71276ff8ce39384",
     "wof:hierarchy":[
         {
@@ -225,7 +228,7 @@
         }
     ],
     "wof:id":421191637,
-    "wof:lastmodified":1566584952,
+    "wof:lastmodified":1582318806,
     "wof:name":"Gramsh",
     "wof:parent_id":85667815,
     "wof:placetype":"county",

--- a/data/421/192/831/421192831.geojson
+++ b/data/421/192/831/421192831.geojson
@@ -218,6 +218,9 @@
     },
     "wof:country":"AL",
     "wof:created":1459009750,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9134336622f9efe34a4aa7a4b0f352fd",
     "wof:hierarchy":[
         {
@@ -228,7 +231,7 @@
         }
     ],
     "wof:id":421192831,
-    "wof:lastmodified":1566584943,
+    "wof:lastmodified":1582318804,
     "wof:name":"P\u00ebrmet",
     "wof:parent_id":85667819,
     "wof:placetype":"county",

--- a/data/421/193/315/421193315.geojson
+++ b/data/421/193/315/421193315.geojson
@@ -221,6 +221,9 @@
     },
     "wof:country":"AL",
     "wof:created":1459009767,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9b1c492a46168dcc8fd2bbf9e24cbd8f",
     "wof:hierarchy":[
         {
@@ -231,7 +234,7 @@
         }
     ],
     "wof:id":421193315,
-    "wof:lastmodified":1566584944,
+    "wof:lastmodified":1582318805,
     "wof:name":"Puk\u00eb",
     "wof:parent_id":85667793,
     "wof:placetype":"county",

--- a/data/421/193/353/421193353.geojson
+++ b/data/421/193/353/421193353.geojson
@@ -227,6 +227,9 @@
     },
     "wof:country":"AL",
     "wof:created":1459009768,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7e1722f11a502efb72cf255368133a4f",
     "wof:hierarchy":[
         {
@@ -237,7 +240,7 @@
         }
     ],
     "wof:id":421193353,
-    "wof:lastmodified":1566584944,
+    "wof:lastmodified":1582318804,
     "wof:name":"Vlor\u00eb",
     "wof:parent_id":85667801,
     "wof:placetype":"county",

--- a/data/421/193/597/421193597.geojson
+++ b/data/421/193/597/421193597.geojson
@@ -213,6 +213,9 @@
     },
     "wof:country":"AL",
     "wof:created":1459009776,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4c80008046a5b0dbf880efec44aefbb4",
     "wof:hierarchy":[
         {
@@ -223,7 +226,7 @@
         }
     ],
     "wof:id":421193597,
-    "wof:lastmodified":1566584945,
+    "wof:lastmodified":1582318805,
     "wof:name":"Kolonj\u00eb",
     "wof:parent_id":85667807,
     "wof:placetype":"county",

--- a/data/421/194/959/421194959.geojson
+++ b/data/421/194/959/421194959.geojson
@@ -221,6 +221,9 @@
     },
     "wof:country":"AL",
     "wof:created":1459009826,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c0b2a4fd5733bda9c72b819e4f811869",
     "wof:hierarchy":[
         {
@@ -231,7 +234,7 @@
         }
     ],
     "wof:id":421194959,
-    "wof:lastmodified":1566584944,
+    "wof:lastmodified":1582318804,
     "wof:name":"Skrapar",
     "wof:parent_id":85667811,
     "wof:placetype":"county",

--- a/data/421/199/463/421199463.geojson
+++ b/data/421/199/463/421199463.geojson
@@ -209,6 +209,9 @@
     },
     "wof:country":"AL",
     "wof:created":1459009990,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"48a3b1527a635ddac47a8b3d1fd7643d",
     "wof:hierarchy":[
         {
@@ -219,7 +222,7 @@
         }
     ],
     "wof:id":421199463,
-    "wof:lastmodified":1566584953,
+    "wof:lastmodified":1582318806,
     "wof:name":"Librazhd",
     "wof:parent_id":85667815,
     "wof:placetype":"county",

--- a/data/421/200/781/421200781.geojson
+++ b/data/421/200/781/421200781.geojson
@@ -221,6 +221,9 @@
     },
     "wof:country":"AL",
     "wof:created":1459010041,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f9e8998dd782a221f818826bef4b44ae",
     "wof:hierarchy":[
         {
@@ -231,7 +234,7 @@
         }
     ],
     "wof:id":421200781,
-    "wof:lastmodified":1566584954,
+    "wof:lastmodified":1582318806,
     "wof:name":"Tropoj\u00eb",
     "wof:parent_id":85667797,
     "wof:placetype":"county",

--- a/data/421/202/101/421202101.geojson
+++ b/data/421/202/101/421202101.geojson
@@ -127,6 +127,9 @@
     },
     "wof:country":"AL",
     "wof:created":1459010105,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1feafd8edc19be6722bc8bad252000e0",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
         }
     ],
     "wof:id":421202101,
-    "wof:lastmodified":1566584946,
+    "wof:lastmodified":1582318805,
     "wof:name":"Vor\u00eb",
     "wof:parent_id":1108720911,
     "wof:placetype":"locality",

--- a/data/421/202/751/421202751.geojson
+++ b/data/421/202/751/421202751.geojson
@@ -209,6 +209,9 @@
     },
     "wof:country":"AL",
     "wof:created":1459010128,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2e4279347a473cfe6c280c224b57bd59",
     "wof:hierarchy":[
         {
@@ -219,7 +222,7 @@
         }
     ],
     "wof:id":421202751,
-    "wof:lastmodified":1566584946,
+    "wof:lastmodified":1582318805,
     "wof:name":"Mat",
     "wof:parent_id":85667821,
     "wof:placetype":"county",

--- a/data/856/324/05/85632405.geojson
+++ b/data/856/324/05/85632405.geojson
@@ -1036,7 +1036,8 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "naturalearth",
-        "meso"
+        "meso",
+        "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"wk",
@@ -1091,6 +1092,11 @@
     },
     "wof:country":"AL",
     "wof:country_alpha3":"ALB",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6",
+        "meso",
+        "naturalearth"
+    ],
     "wof:geomhash":"43ababe5967dfc80ce4cb8846cdb45e1",
     "wof:hierarchy":[
         {
@@ -1105,7 +1111,7 @@
     "wof:lang_x_spoken":[
         "sqi"
     ],
-    "wof:lastmodified":1566584690,
+    "wof:lastmodified":1582318798,
     "wof:name":"Albania",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/856/324/05/85632405.geojson
+++ b/data/856/324/05/85632405.geojson
@@ -1036,8 +1036,7 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "naturalearth",
-        "meso",
-        "naturalearth"
+        "meso"
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"wk",
@@ -1111,7 +1110,7 @@
     "wof:lang_x_spoken":[
         "sqi"
     ],
-    "wof:lastmodified":1582318798,
+    "wof:lastmodified":1583205633,
     "wof:name":"Albania",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/856/677/83/85667783.geojson
+++ b/data/856/677/83/85667783.geojson
@@ -354,6 +354,9 @@
         "wk:page":"Durr\u00ebs County"
     },
     "wof:country":"AL",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a56b0eac706b35131be48cef555c09e8",
     "wof:hierarchy":[
         {
@@ -369,7 +372,7 @@
     "wof:lang_x_spoken":[
         "sqi"
     ],
-    "wof:lastmodified":1566584695,
+    "wof:lastmodified":1582318800,
     "wof:name":"Durr\u00ebs",
     "wof:parent_id":85632405,
     "wof:placetype":"region",

--- a/data/856/677/89/85667789.geojson
+++ b/data/856/677/89/85667789.geojson
@@ -299,6 +299,9 @@
         "wk:page":"Fier County"
     },
     "wof:country":"AL",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a23f7719561be0ab4e29e1c84b5d3337",
     "wof:hierarchy":[
         {
@@ -314,7 +317,7 @@
     "wof:lang_x_spoken":[
         "sqi"
     ],
-    "wof:lastmodified":1566584694,
+    "wof:lastmodified":1582318800,
     "wof:name":"Fier",
     "wof:parent_id":85632405,
     "wof:placetype":"region",

--- a/data/856/677/93/85667793.geojson
+++ b/data/856/677/93/85667793.geojson
@@ -295,6 +295,9 @@
         "wk:page":"Shkod\u00ebr County"
     },
     "wof:country":"AL",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"62cf645b29b3a77c32e3e28ee7922dcf",
     "wof:hierarchy":[
         {
@@ -310,7 +313,7 @@
     "wof:lang_x_spoken":[
         "sqi"
     ],
-    "wof:lastmodified":1566584694,
+    "wof:lastmodified":1582318800,
     "wof:name":"Shkod\u00ebr",
     "wof:parent_id":85632405,
     "wof:placetype":"region",

--- a/data/856/677/97/85667797.geojson
+++ b/data/856/677/97/85667797.geojson
@@ -308,6 +308,9 @@
         "wk:page":"Kuk\u00ebs County"
     },
     "wof:country":"AL",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a8c3c36f488b335c02578f3ee62ccb06",
     "wof:hierarchy":[
         {
@@ -323,7 +326,7 @@
     "wof:lang_x_spoken":[
         "sqi"
     ],
-    "wof:lastmodified":1566584694,
+    "wof:lastmodified":1582318800,
     "wof:name":"Kuk\u00ebs",
     "wof:parent_id":85632405,
     "wof:placetype":"region",

--- a/data/856/678/01/85667801.geojson
+++ b/data/856/678/01/85667801.geojson
@@ -343,6 +343,9 @@
         "wk:page":"Vlor\u00eb County"
     },
     "wof:country":"AL",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a72dafa32b5764786cdd3255c6b71fca",
     "wof:hierarchy":[
         {
@@ -358,7 +361,7 @@
     "wof:lang_x_spoken":[
         "sqi"
     ],
-    "wof:lastmodified":1566584693,
+    "wof:lastmodified":1582318800,
     "wof:name":"Vlor\u00eb",
     "wof:parent_id":85632405,
     "wof:placetype":"region",

--- a/data/856/678/07/85667807.geojson
+++ b/data/856/678/07/85667807.geojson
@@ -339,6 +339,9 @@
         "wd:id":"Q193464"
     },
     "wof:country":"AL",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fa3cb11164358b7022a6cdd66cce34e3",
     "wof:hierarchy":[
         {
@@ -354,7 +357,7 @@
     "wof:lang_x_spoken":[
         "sqi"
     ],
-    "wof:lastmodified":1566584692,
+    "wof:lastmodified":1582318800,
     "wof:name":"Kor\u00e7\u00eb",
     "wof:parent_id":85632405,
     "wof:placetype":"region",

--- a/data/856/678/11/85667811.geojson
+++ b/data/856/678/11/85667811.geojson
@@ -350,6 +350,9 @@
         "wk:page":"Berat County"
     },
     "wof:country":"AL",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fe43c19ca9cf28d710fb8fade9c4a6a6",
     "wof:hierarchy":[
         {
@@ -365,7 +368,7 @@
     "wof:lang_x_spoken":[
         "sqi"
     ],
-    "wof:lastmodified":1566584691,
+    "wof:lastmodified":1582318799,
     "wof:name":"Berat",
     "wof:parent_id":85632405,
     "wof:placetype":"region",

--- a/data/856/678/15/85667815.geojson
+++ b/data/856/678/15/85667815.geojson
@@ -308,6 +308,9 @@
         "wk:page":"Elbasan County"
     },
     "wof:country":"AL",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"19469934733c1a6ed2d1a18f51f86690",
     "wof:hierarchy":[
         {
@@ -323,7 +326,7 @@
     "wof:lang_x_spoken":[
         "sqi"
     ],
-    "wof:lastmodified":1566584693,
+    "wof:lastmodified":1582318800,
     "wof:name":"Elbasan",
     "wof:parent_id":85632405,
     "wof:placetype":"region",

--- a/data/856/678/19/85667819.geojson
+++ b/data/856/678/19/85667819.geojson
@@ -348,6 +348,9 @@
         "wk:page":"Gjirokast\u00ebr County"
     },
     "wof:country":"AL",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e3dcb07d7b74a1cdca528f80dc07f26a",
     "wof:hierarchy":[
         {
@@ -363,7 +366,7 @@
     "wof:lang_x_spoken":[
         "sqi"
     ],
-    "wof:lastmodified":1566584692,
+    "wof:lastmodified":1582318799,
     "wof:name":"Gjirokast\u00eb",
     "wof:parent_id":85632405,
     "wof:placetype":"region",

--- a/data/856/678/21/85667821.geojson
+++ b/data/856/678/21/85667821.geojson
@@ -315,6 +315,9 @@
         "wk:page":"Dib\u00ebr County"
     },
     "wof:country":"AL",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5f93788e7f01e215ed2e8c8cf67e39ce",
     "wof:hierarchy":[
         {
@@ -330,7 +333,7 @@
     "wof:lang_x_spoken":[
         "sqi"
     ],
-    "wof:lastmodified":1566584692,
+    "wof:lastmodified":1582318799,
     "wof:name":"Dib\u00ebr",
     "wof:parent_id":85632405,
     "wof:placetype":"region",

--- a/data/856/678/29/85667829.geojson
+++ b/data/856/678/29/85667829.geojson
@@ -309,6 +309,9 @@
         "wk:page":"Lezh\u00eb County"
     },
     "wof:country":"AL",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0482a720f710128d5d81f8a14a728671",
     "wof:hierarchy":[
         {
@@ -324,7 +327,7 @@
     "wof:lang_x_spoken":[
         "sqi"
     ],
-    "wof:lastmodified":1566584691,
+    "wof:lastmodified":1582318799,
     "wof:name":"Lezh\u00eb",
     "wof:parent_id":85632405,
     "wof:placetype":"region",

--- a/data/858/977/43/85897743.geojson
+++ b/data/858/977/43/85897743.geojson
@@ -78,6 +78,9 @@
         "qs_pg:id":1165524
     },
     "wof:country":"AL",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a48afbf96855ac42f8f374c0015b06f6",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566584695,
+    "wof:lastmodified":1582318801,
     "wof:name":"Kostren i Math",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.