### PR TITLE
al concordances, placetype local, and more

### DIFF
--- a/data/110/872/084/7/1108720847.geojson
+++ b/data/110/872/084/7/1108720847.geojson
@@ -122,6 +122,7 @@
         "eurostat:nuts_2021_id":"AL211",
         "hasc:id":"AL.EB.BS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AL",
     "wof:created":1476125653,
     "wof:geomhash":"6e88034a10d2838f4b1146d1a490db89",
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":1108720847,
-    "wof:lastmodified":1684351506,
+    "wof:lastmodified":1695886591,
     "wof:name":"Belsh",
     "wof:parent_id":85667815,
     "wof:placetype":"county",

--- a/data/110/872/084/9/1108720849.geojson
+++ b/data/110/872/084/9/1108720849.geojson
@@ -158,6 +158,7 @@
         "eurostat:nuts_2021_id":"AL212",
         "hasc:id":"AL.EB.CK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AL",
     "wof:created":1476125656,
     "wof:geomhash":"e105dd4aa56e4c6d5d5ebcfe97b9c21c",
@@ -170,7 +171,7 @@
         }
     ],
     "wof:id":1108720849,
-    "wof:lastmodified":1684351506,
+    "wof:lastmodified":1695886591,
     "wof:name":"C\u00ebrrik",
     "wof:parent_id":85667815,
     "wof:placetype":"county",

--- a/data/110/872/085/1/1108720851.geojson
+++ b/data/110/872/085/1/1108720851.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":26716,
     "eurostat:population_year":2019,
     "geom:area":0.048826,
-    "geom:area_square_m":458430236.485124,
+    "geom:area_square_m":458430123.191796,
     "geom:bbox":"20.765414,40.432002,21.057282,40.756717",
     "geom:latitude":40.596081,
     "geom:longitude":20.928807,
@@ -211,11 +211,16 @@
         "eg:gisco_id":"AL_AL341",
         "eurostat:nuts_2021_id":"AL341",
         "hasc:id":"AL.KE.DV",
+        "iso:code_historic":"AL-DV",
         "wd:id":"Q192126"
     },
+    "wof:concordances_official":"iso:code_historic",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"AL",
     "wof:created":1476125658,
-    "wof:geomhash":"a1cc1a0ee2b9830463a4ded40eb93a99",
+    "wof:geomhash":"a074886de60d016c4271d82c694293a5",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -225,7 +230,7 @@
         }
     ],
     "wof:id":1108720851,
-    "wof:lastmodified":1690849764,
+    "wof:lastmodified":1695886591,
     "wof:name":"Devoll",
     "wof:parent_id":85667807,
     "wof:placetype":"county",

--- a/data/110/872/085/3/1108720853.geojson
+++ b/data/110/872/085/3/1108720853.geojson
@@ -140,6 +140,7 @@
         "eurostat:nuts_2021_id":"AL321",
         "hasc:id":"AL.FI.DJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AL",
     "wof:created":1476125660,
     "wof:geomhash":"b7c54446ac1d0daf6d502bfc79d57d37",
@@ -152,7 +153,7 @@
         }
     ],
     "wof:id":1108720853,
-    "wof:lastmodified":1684351506,
+    "wof:lastmodified":1695886591,
     "wof:name":"Divjak\u00eb",
     "wof:parent_id":85667789,
     "wof:placetype":"county",

--- a/data/110/872/085/5/1108720855.geojson
+++ b/data/110/872/085/5/1108720855.geojson
@@ -92,6 +92,7 @@
         "eurostat:nuts_2021_id":"AL331",
         "hasc:id":"AL.GK.DO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AL",
     "wof:created":1476125667,
     "wof:geomhash":"0ba954dd00ab070e3ef5de9fb5156b66",
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1108720855,
-    "wof:lastmodified":1684351506,
+    "wof:lastmodified":1695886591,
     "wof:name":"Dropull",
     "wof:parent_id":85667819,
     "wof:placetype":"county",

--- a/data/110/872/085/7/1108720857.geojson
+++ b/data/110/872/085/7/1108720857.geojson
@@ -113,6 +113,7 @@
         "eurostat:nuts_2021_id":"AL354",
         "hasc:id":"AL.VR.FN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AL",
     "wof:created":1476125669,
     "wof:geomhash":"dbd30ef8354478ec1ebc1e846eb186c5",
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":1108720857,
-    "wof:lastmodified":1684351506,
+    "wof:lastmodified":1695886591,
     "wof:name":"Finiq",
     "wof:parent_id":85667801,
     "wof:placetype":"county",

--- a/data/110/872/085/9/1108720859.geojson
+++ b/data/110/872/085/9/1108720859.geojson
@@ -74,6 +74,7 @@
         "eurostat:nuts_2021_id":"AL151",
         "hasc:id":"AL.SD.FU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AL",
     "wof:created":1476125670,
     "wof:geomhash":"2841b983c883851fb17767dc0a212fdf",
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1108720859,
-    "wof:lastmodified":1684351506,
+    "wof:lastmodified":1695886591,
     "wof:name":"Fush\u00eb Arr\u00ebs",
     "wof:parent_id":85667793,
     "wof:placetype":"county",

--- a/data/110/872/086/1/1108720861.geojson
+++ b/data/110/872/086/1/1108720861.geojson
@@ -74,6 +74,7 @@
         "eurostat:nuts_2021_id":"AL352",
         "hasc:id":"AL.VR.HM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AL",
     "wof:created":1476125673,
     "wof:geomhash":"578004749f92e80c5aa7b64f4add1bbd",
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1108720861,
-    "wof:lastmodified":1684351506,
+    "wof:lastmodified":1695886591,
     "wof:name":"Himar\u00eb",
     "wof:parent_id":85667801,
     "wof:placetype":"county",

--- a/data/110/872/086/5/1108720865.geojson
+++ b/data/110/872/086/5/1108720865.geojson
@@ -149,6 +149,7 @@
         "eurostat:nuts_2021_id":"AL221",
         "hasc:id":"AL.TI.KM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AL",
     "wof:created":1476125674,
     "wof:geomhash":"e958b0ed0a5c7e491ee207772f58c620",
@@ -161,7 +162,7 @@
         }
     ],
     "wof:id":1108720865,
-    "wof:lastmodified":1684351506,
+    "wof:lastmodified":1695886592,
     "wof:name":"Kam\u00ebz",
     "wof:parent_id":1108803089,
     "wof:placetype":"county",

--- a/data/110/872/086/7/1108720867.geojson
+++ b/data/110/872/086/7/1108720867.geojson
@@ -95,6 +95,7 @@
         "eurostat:nuts_2021_id":"AL113",
         "hasc:id":"AL.DB.KS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AL",
     "wof:created":1476125675,
     "wof:geomhash":"67dfa101f08c0ef3bae21d7f9909cfbd",
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1108720867,
-    "wof:lastmodified":1684351506,
+    "wof:lastmodified":1695886592,
     "wof:name":"Klos",
     "wof:parent_id":85667821,
     "wof:placetype":"county",

--- a/data/110/872/086/9/1108720869.geojson
+++ b/data/110/872/086/9/1108720869.geojson
@@ -146,6 +146,7 @@
         "eurostat:nuts_2021_id":"AL353",
         "hasc:id":"AL.VR.KN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AL",
     "wof:created":1476125677,
     "wof:geomhash":"2e7d58e428dd8dbb3384aa59ff94f9ad",
@@ -158,7 +159,7 @@
         }
     ],
     "wof:id":1108720869,
-    "wof:lastmodified":1684351506,
+    "wof:lastmodified":1695886592,
     "wof:name":"Konispol",
     "wof:parent_id":85667801,
     "wof:placetype":"county",

--- a/data/110/872/087/1/1108720871.geojson
+++ b/data/110/872/087/1/1108720871.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":31262,
     "eurostat:population_year":2019,
     "geom:area":0.017147,
-    "geom:area_square_m":160465350.999925,
+    "geom:area_square_m":160465458.943407,
     "geom:bbox":"19.837984,40.764717,20.089562,40.874869",
     "geom:latitude":40.817158,
     "geom:longitude":19.958074,
@@ -208,11 +208,16 @@
         "eg:gisco_id":"AL_AL312",
         "eurostat:nuts_2021_id":"AL312",
         "hasc:id":"AL.BE.KV",
+        "iso:code_historic":"AL-KC",
         "wd:id":"Q211946"
     },
+    "wof:concordances_official":"iso:code_historic",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"AL",
     "wof:created":1476125681,
-    "wof:geomhash":"7d98c631980f1babb3d2cb41812c3806",
+    "wof:geomhash":"73a2dc99329ab07a4089f1aa7074b772",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -222,7 +227,7 @@
         }
     ],
     "wof:id":1108720871,
-    "wof:lastmodified":1690849765,
+    "wof:lastmodified":1695886592,
     "wof:name":"Ku\u00e7ov\u00eb",
     "wof:parent_id":85667811,
     "wof:placetype":"county",

--- a/data/110/872/087/3/1108720873.geojson
+++ b/data/110/872/087/3/1108720873.geojson
@@ -122,6 +122,7 @@
         "eurostat:nuts_2021_id":"AL333",
         "hasc:id":"AL.GK.KY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AL",
     "wof:created":1476125683,
     "wof:geomhash":"407f22015c135993e9f881dfe025055d",
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":1108720873,
-    "wof:lastmodified":1684351506,
+    "wof:lastmodified":1695886592,
     "wof:name":"K\u00eblcyr\u00eb",
     "wof:parent_id":85667819,
     "wof:placetype":"county",

--- a/data/110/872/087/5/1108720875.geojson
+++ b/data/110/872/087/5/1108720875.geojson
@@ -143,6 +143,7 @@
         "eurostat:nuts_2021_id":"AL334",
         "hasc:id":"AL.GK.LH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AL",
     "wof:created":1476125685,
     "wof:geomhash":"6c46456a274f7d87a060a0df7b46b442",
@@ -155,7 +156,7 @@
         }
     ],
     "wof:id":1108720875,
-    "wof:lastmodified":1684351506,
+    "wof:lastmodified":1695886592,
     "wof:name":"Libohov\u00eb",
     "wof:parent_id":85667819,
     "wof:placetype":"county",

--- a/data/110/872/087/7/1108720877.geojson
+++ b/data/110/872/087/7/1108720877.geojson
@@ -125,6 +125,7 @@
         "eurostat:nuts_2021_id":"AL344",
         "hasc:id":"AL.KE.MQ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AL",
     "wof:created":1476125687,
     "wof:geomhash":"3ba9fc86bb30b91d4416b28100714d77",
@@ -137,7 +138,7 @@
         }
     ],
     "wof:id":1108720877,
-    "wof:lastmodified":1684351506,
+    "wof:lastmodified":1695886592,
     "wof:name":"Maliq",
     "wof:parent_id":85667807,
     "wof:placetype":"county",

--- a/data/110/872/087/9/1108720879.geojson
+++ b/data/110/872/087/9/1108720879.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":27062,
     "eurostat:population_year":2019,
     "geom:area":0.034741,
-    "geom:area_square_m":326385923.755521,
+    "geom:area_square_m":326386098.9017,
     "geom:bbox":"19.650512,40.419233,19.92349,40.663807",
     "geom:latitude":40.554477,
     "geom:longitude":19.776391,
@@ -190,11 +190,16 @@
         "eg:gisco_id":"AL_AL324",
         "eurostat:nuts_2021_id":"AL324",
         "hasc:id":"AL.FI.MK",
+        "iso:code_historic":"AL-MK",
         "wd:id":"Q207437"
     },
+    "wof:concordances_official":"iso:code_historic",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"AL",
     "wof:created":1476125688,
-    "wof:geomhash":"2fbed43d7730db72f87a2415052f1f63",
+    "wof:geomhash":"5d7bf93eccef6bc6c0ce362aa3f25fca",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -204,7 +209,7 @@
         }
     ],
     "wof:id":1108720879,
-    "wof:lastmodified":1690849764,
+    "wof:lastmodified":1695886592,
     "wof:name":"Mallakast\u00ebr",
     "wof:parent_id":85667789,
     "wof:placetype":"county",

--- a/data/110/872/088/3/1108720883.geojson
+++ b/data/110/872/088/3/1108720883.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":30823,
     "eurostat:population_year":2019,
     "geom:area":0.114258,
-    "geom:area_square_m":1044096267.322174,
+    "geom:area_square_m":1044096015.812403,
     "geom:bbox":"19.289555,42.113509,19.787562,42.661082",
     "geom:latitude":42.352516,
     "geom:longitude":19.561191,
@@ -205,11 +205,16 @@
         "eg:gisco_id":"AL_AL152",
         "eurostat:nuts_2021_id":"AL152",
         "hasc:id":"AL.SD.MM",
+        "iso:code_historic":"AL-MM",
         "wd:id":"Q236845"
     },
+    "wof:concordances_official":"iso:code_historic",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"AL",
     "wof:created":1476125689,
-    "wof:geomhash":"1f3c4cde77c7f73c9eff10ce1d7ceb05",
+    "wof:geomhash":"241b8816ee94c4ee72e27e8940090c9b",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -219,7 +224,7 @@
         }
     ],
     "wof:id":1108720883,
-    "wof:lastmodified":1690849765,
+    "wof:lastmodified":1695886592,
     "wof:name":"Mal\u00ebsi E Madhe",
     "wof:parent_id":85667793,
     "wof:placetype":"county",

--- a/data/110/872/088/5/1108720885.geojson
+++ b/data/110/872/088/5/1108720885.geojson
@@ -131,6 +131,7 @@
         "eurostat:nuts_2021_id":"AL337",
         "hasc:id":"AL.GK.ML"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AL",
     "wof:created":1476125691,
     "wof:geomhash":"43f49469eda8469081139de59a430372",
@@ -143,7 +144,7 @@
         }
     ],
     "wof:id":1108720885,
-    "wof:lastmodified":1684351506,
+    "wof:lastmodified":1695886593,
     "wof:name":"Memaliaj",
     "wof:parent_id":85667819,
     "wof:placetype":"county",

--- a/data/110/872/088/7/1108720887.geojson
+++ b/data/110/872/088/7/1108720887.geojson
@@ -149,6 +149,7 @@
         "eurostat:nuts_2021_id":"AL326",
         "hasc:id":"AL.FI.PT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AL",
     "wof:created":1476125692,
     "wof:geomhash":"05c2b97781e15387bf6f417d6f20d7ad",
@@ -161,7 +162,7 @@
         }
     ],
     "wof:id":1108720887,
-    "wof:lastmodified":1684351507,
+    "wof:lastmodified":1695886595,
     "wof:name":"Patos",
     "wof:parent_id":85667789,
     "wof:placetype":"county",

--- a/data/110/872/088/9/1108720889.geojson
+++ b/data/110/872/088/9/1108720889.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":26136,
     "eurostat:population_year":2019,
     "geom:area":0.021241,
-    "geom:area_square_m":198020733.978924,
+    "geom:area_square_m":198020701.589935,
     "geom:bbox":"19.675456,40.989268,19.90358,41.158854",
     "geom:latitude":41.06701,
     "geom:longitude":19.79683,
@@ -193,11 +193,16 @@
         "eg:gisco_id":"AL_AL216",
         "eurostat:nuts_2021_id":"AL216",
         "hasc:id":"AL.EB.PN",
+        "iso:code_historic":"AL-PQ",
         "wd:id":"Q202652"
     },
+    "wof:concordances_official":"iso:code_historic",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"AL",
     "wof:created":1476125693,
-    "wof:geomhash":"23cc9cadb3f2454bb9d3eef477d2cfde",
+    "wof:geomhash":"52cabf58a7e02ce37bded347cce375a8",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -207,7 +212,7 @@
         }
     ],
     "wof:id":1108720889,
-    "wof:lastmodified":1690849765,
+    "wof:lastmodified":1695886595,
     "wof:name":"Peqin",
     "wof:parent_id":85667815,
     "wof:placetype":"county",

--- a/data/110/872/089/1/1108720891.geojson
+++ b/data/110/872/089/1/1108720891.geojson
@@ -140,6 +140,7 @@
         "eurostat:nuts_2021_id":"AL313",
         "hasc:id":"AL.BE.PO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AL",
     "wof:created":1476125695,
     "wof:geomhash":"86b083223bd18487b9e1c8bb9e40d404",
@@ -152,7 +153,7 @@
         }
     ],
     "wof:id":1108720891,
-    "wof:lastmodified":1684351507,
+    "wof:lastmodified":1695886595,
     "wof:name":"Poli\u00e7an",
     "wof:parent_id":85667811,
     "wof:placetype":"county",

--- a/data/110/872/089/3/1108720893.geojson
+++ b/data/110/872/089/3/1108720893.geojson
@@ -122,6 +122,7 @@
         "eurostat:nuts_2021_id":"AL217",
         "hasc:id":"AL.EB.PS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AL",
     "wof:created":1476125696,
     "wof:geomhash":"d0a23601738df9ab2d4c8aea14daa377",
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":1108720893,
-    "wof:lastmodified":1684351507,
+    "wof:lastmodified":1695886595,
     "wof:name":"Prrenjas",
     "wof:parent_id":85667815,
     "wof:placetype":"county",

--- a/data/110/872/089/5/1108720895.geojson
+++ b/data/110/872/089/5/1108720895.geojson
@@ -98,6 +98,7 @@
         "eurostat:nuts_2021_id":"AL346",
         "hasc:id":"AL.KE.PC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AL",
     "wof:created":1476125698,
     "wof:geomhash":"6b5b120e02b7ab79eff1479a06329791",
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1108720895,
-    "wof:lastmodified":1684351507,
+    "wof:lastmodified":1695886595,
     "wof:name":"Pustec",
     "wof:parent_id":85667807,
     "wof:placetype":"county",

--- a/data/110/872/089/7/1108720897.geojson
+++ b/data/110/872/089/7/1108720897.geojson
@@ -140,6 +140,7 @@
         "eurostat:nuts_2021_id":"AL325",
         "hasc:id":"AL.FI.RV"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AL",
     "wof:created":1476125700,
     "wof:geomhash":"9cd4abffa561b441a57b045ab2350fbf",
@@ -152,7 +153,7 @@
         }
     ],
     "wof:id":1108720897,
-    "wof:lastmodified":1684351507,
+    "wof:lastmodified":1695886596,
     "wof:name":"Roskovec",
     "wof:parent_id":85667789,
     "wof:placetype":"county",

--- a/data/110/872/090/1/1108720901.geojson
+++ b/data/110/872/090/1/1108720901.geojson
@@ -131,6 +131,7 @@
         "eurostat:nuts_2021_id":"AL223",
         "hasc:id":"AL.TI.RZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AL",
     "wof:created":1476125701,
     "wof:geomhash":"1541a284dea78baf2832099f66248810",
@@ -143,7 +144,7 @@
         }
     ],
     "wof:id":1108720901,
-    "wof:lastmodified":1684351507,
+    "wof:lastmodified":1695886596,
     "wof:name":"Rrogozhin\u00eb",
     "wof:parent_id":1108803089,
     "wof:placetype":"county",

--- a/data/110/872/090/3/1108720903.geojson
+++ b/data/110/872/090/3/1108720903.geojson
@@ -137,6 +137,7 @@
         "eurostat:nuts_2021_id":"AL356",
         "hasc:id":"AL.VR.SE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AL",
     "wof:created":1476125703,
     "wof:geomhash":"05f666c4d6b9bc8a181af30a5f6f1ce3",
@@ -149,7 +150,7 @@
         }
     ],
     "wof:id":1108720903,
-    "wof:lastmodified":1684351507,
+    "wof:lastmodified":1695886596,
     "wof:name":"Selenic\u00eb",
     "wof:parent_id":85667801,
     "wof:placetype":"county",

--- a/data/110/872/090/5/1108720905.geojson
+++ b/data/110/872/090/5/1108720905.geojson
@@ -152,6 +152,7 @@
         "eurostat:nuts_2021_id":"AL123",
         "hasc:id":"AL.DU.SJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AL",
     "wof:created":1476125704,
     "wof:geomhash":"8580c4772cbb2d747e94ab50d92d09fc",
@@ -164,7 +165,7 @@
         }
     ],
     "wof:id":1108720905,
-    "wof:lastmodified":1684351507,
+    "wof:lastmodified":1695886596,
     "wof:name":"Shijak",
     "wof:parent_id":85667783,
     "wof:placetype":"county",

--- a/data/110/872/090/7/1108720907.geojson
+++ b/data/110/872/090/7/1108720907.geojson
@@ -131,6 +131,7 @@
         "eurostat:nuts_2021_id":"AL315",
         "hasc:id":"AL.BE.UR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AL",
     "wof:created":1476125708,
     "wof:geomhash":"c83684373cafa3dacecbe64e1e357c32",
@@ -143,7 +144,7 @@
         }
     ],
     "wof:id":1108720907,
-    "wof:lastmodified":1684351507,
+    "wof:lastmodified":1695886596,
     "wof:name":"Ura Vajgurore",
     "wof:parent_id":85667811,
     "wof:placetype":"county",

--- a/data/110/872/090/9/1108720909.geojson
+++ b/data/110/872/090/9/1108720909.geojson
@@ -74,6 +74,7 @@
         "eurostat:nuts_2021_id":"AL155",
         "hasc:id":"AL.SD.VI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AL",
     "wof:created":1476125709,
     "wof:geomhash":"90dd44904ab30b9180f9b759567a0ed4",
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1108720909,
-    "wof:lastmodified":1684351507,
+    "wof:lastmodified":1695886596,
     "wof:name":"Vau I Dej\u00ebs",
     "wof:parent_id":85667793,
     "wof:placetype":"county",

--- a/data/110/872/091/1/1108720911.geojson
+++ b/data/110/872/091/1/1108720911.geojson
@@ -122,6 +122,7 @@
         "eurostat:nuts_2021_id":"AL225",
         "hasc:id":"AL.TI.VR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AL",
     "wof:created":1476125711,
     "wof:geomhash":"54bee8f6910c0c9d13cbb3ff20f37f61",
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":1108720911,
-    "wof:lastmodified":1684351507,
+    "wof:lastmodified":1695886596,
     "wof:name":"Vor\u00eb",
     "wof:parent_id":1108803089,
     "wof:placetype":"county",

--- a/data/110/880/308/9/1108803089.geojson
+++ b/data/110/880/308/9/1108803089.geojson
@@ -19,7 +19,7 @@
     "eurostat:population_year":2021,
     "eurostat:urban_type":"1",
     "geom:area":0.177068,
-    "geom:area_square_m":1645649970.064466,
+    "geom:area_square_m":1645649753.684397,
     "geom:bbox":"19.430389,41.002106,20.233729,41.517134",
     "geom:latitude":41.269464,
     "geom:longitude":19.792985,
@@ -269,12 +269,14 @@
         "eurostat:nuts_2021_id":"AL022",
         "fips:code":"AL50",
         "hasc:id":"AL.TI",
+        "iso:code":"AL-11",
         "iso:id":"AL-11",
         "wd:id":"Q229892"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AL",
     "wof:created":1485211661,
-    "wof:geomhash":"42e7fd8963f7ac0ea00e3b963192545e",
+    "wof:geomhash":"6da98711be839e848a093ee3526d3aad",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -289,7 +291,7 @@
     "wof:lang_x_spoken":[
         "sqi"
     ],
-    "wof:lastmodified":1690849764,
+    "wof:lastmodified":1695885190,
     "wof:name":"Tiran\u00eb",
     "wof:parent_id":85632405,
     "wof:placetype":"region",

--- a/data/421/167/927/421167927.geojson
+++ b/data/421/167/927/421167927.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":135612,
     "eurostat:population_year":2019,
     "geom:area":0.099156,
-    "geom:area_square_m":908902591.194972,
+    "geom:area_square_m":908902620.91708,
     "geom:bbox":"19.341614,41.84054,19.84748,42.487665",
     "geom:latitude":42.156856,
     "geom:longitude":19.614812,
@@ -256,16 +256,21 @@
         "gn:id":3184083,
         "gp:id":20069928,
         "hasc:id":"AL.SD.SO",
+        "iso:code_historic":"AL-SH",
         "qs_pg:id":277250,
         "wd:id":"Q194176",
         "wk:page":"Shkod\u00ebr"
     },
+    "wof:concordances_official":"iso:code_historic",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"AL",
     "wof:created":1459008748,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1d408c17810e316b233864516699f729",
+    "wof:geomhash":"405f3a654df8d7126e5576177584bd15",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -275,7 +280,7 @@
         }
     ],
     "wof:id":421167927,
-    "wof:lastmodified":1690849768,
+    "wof:lastmodified":1695886585,
     "wof:name":"Shkod\u00ebr",
     "wof:parent_id":85667793,
     "wof:placetype":"county",

--- a/data/421/168/061/421168061.geojson
+++ b/data/421/168/061/421168061.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":16790,
     "eurostat:population_year":2019,
     "geom:area":0.043756,
-    "geom:area_square_m":400843876.299323,
+    "geom:area_square_m":400844227.255026,
     "geom:bbox":"20.21283,42.092435,20.544775,42.308469",
     "geom:latitude":42.194917,
     "geom:longitude":20.384846,
@@ -223,16 +223,21 @@
         "gn:id":831098,
         "gp:id":20069930,
         "hasc:id":"AL.KK.HA",
+        "iso:code_historic":"AL-HA",
         "qs_pg:id":966783,
         "wd:id":"Q207007",
         "wk:page":"Has District"
     },
+    "wof:concordances_official":"iso:code_historic",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"AL",
     "wof:created":1459008752,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d3c91d4dd4711c940a03437e56eecbb1",
+    "wof:geomhash":"db39ce414fb5737a5fab44b98519d483",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -242,7 +247,7 @@
         }
     ],
     "wof:id":421168061,
-    "wof:lastmodified":1690849766,
+    "wof:lastmodified":1695886585,
     "wof:name":"Has",
     "wof:parent_id":85667797,
     "wof:placetype":"county",

--- a/data/421/169/685/421169685.geojson
+++ b/data/421/169/685/421169685.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":61619,
     "eurostat:population_year":2019,
     "geom:area":0.101621,
-    "geom:area_square_m":937804447.748817,
+    "geom:area_square_m":937804225.463653,
     "geom:bbox":"20.116889,41.554284,20.573702,41.907447",
     "geom:latitude":41.726662,
     "geom:longitude":20.350991,
@@ -280,16 +280,21 @@
         "gn:id":783346,
         "gp:id":20069938,
         "hasc:id":"AL.DB.DI",
+        "iso:code_historic":"AL-DI",
         "qs_pg:id":228932,
         "wd:id":"Q192123",
         "wk:page":"Dib\u00ebr District"
     },
+    "wof:concordances_official":"iso:code_historic",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"AL",
     "wof:created":1459008820,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"29babef9a00a97d9392ae451f0b422ea",
+    "wof:geomhash":"a3c280365648fd68a413a7b36267fe88",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -299,7 +304,7 @@
         }
     ],
     "wof:id":421169685,
-    "wof:lastmodified":1690849769,
+    "wof:lastmodified":1695886585,
     "wof:name":"Dib\u00ebr",
     "wof:parent_id":85667821,
     "wof:placetype":"county",

--- a/data/421/169/921/421169921.geojson
+++ b/data/421/169/921/421169921.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":65633,
     "eurostat:population_year":2019,
     "geom:area":0.055844,
-    "geom:area_square_m":514533869.179764,
+    "geom:area_square_m":514533927.428986,
     "geom:bbox":"19.462422,41.654648,19.861005,41.952072",
     "geom:latitude":41.828985,
     "geom:longitude":19.670464,
@@ -277,16 +277,21 @@
         "gn:id":3184937,
         "gp:id":20069933,
         "hasc:id":"AL.LZ.LZ",
+        "iso:code_historic":"AL-LE",
         "qs_pg:id":500852,
         "wd:id":"Q194185",
         "wk:page":"Lezh\u00eb District"
     },
+    "wof:concordances_official":"iso:code_historic",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"AL",
     "wof:created":1459008829,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"61c80e4b6f3166c079e2e849e54e9582",
+    "wof:geomhash":"3657e68ce42b139613f83768ac0d09c8",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -296,7 +301,7 @@
         }
     ],
     "wof:id":421169921,
-    "wof:lastmodified":1690849769,
+    "wof:lastmodified":1695886585,
     "wof:name":"Lezh\u00eb",
     "wof:parent_id":85667829,
     "wof:placetype":"county",

--- a/data/421/178/941/421178941.geojson
+++ b/data/421/178/941/421178941.geojson
@@ -300,16 +300,21 @@
         "gn:id":781988,
         "gp:id":20069943,
         "hasc:id":"AL.KE.PG",
+        "iso:code_historic":"AL-PG",
         "qs_pg:id":316226,
         "wd:id":"Q202197",
         "wk:page":"Pogradec"
     },
+    "wof:concordances_official":"iso:code_historic",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"AL",
     "wof:created":1459009198,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1f351ff2a7182c0c65a574cd0cd0049e",
+    "wof:geomhash":"444ab17417c7ca61380305871ed010b7",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -319,7 +324,7 @@
         }
     ],
     "wof:id":421178941,
-    "wof:lastmodified":1690849782,
+    "wof:lastmodified":1695886585,
     "wof:name":"Pogradec",
     "wof:parent_id":85667807,
     "wof:placetype":"county",

--- a/data/421/179/955/421179955.geojson
+++ b/data/421/179/955/421179955.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":23183,
     "eurostat:population_year":2019,
     "geom:area":0.007289,
-    "geom:area_square_m":69207104.431242,
+    "geom:area_square_m":69207104.098907,
     "geom:bbox":"19.932882,39.741374,20.06048,39.919826",
     "geom:latitude":39.842104,
     "geom:longitude":20.006299,
@@ -389,16 +389,21 @@
         "gn:id":363243,
         "gp:id":20069961,
         "hasc:id":"AL.VR.SR",
+        "iso:code_historic":"AL-SR",
         "qs_pg:id":273773,
         "wd:id":"Q748235",
         "wk:page":"Sarand\u00eb"
     },
+    "wof:concordances_official":"iso:code_historic",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"AL",
     "wof:created":1459009239,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bdf3aa9882b3440ccaa41b5d5b6cf91a",
+    "wof:geomhash":"a9be49235029fc2e9ed674cb6006ae56",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -408,7 +413,7 @@
         }
     ],
     "wof:id":421179955,
-    "wof:lastmodified":1690849782,
+    "wof:lastmodified":1695886586,
     "wof:name":"Sarand\u00eb",
     "wof:parent_id":85667801,
     "wof:placetype":"county",

--- a/data/421/181/321/421181321.geojson
+++ b/data/421/181/321/421181321.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":46291,
     "eurostat:population_year":2019,
     "geom:area":0.02907,
-    "geom:area_square_m":268672630.401752,
+    "geom:area_square_m":268672700.699304,
     "geom:bbox":"19.561239,41.556874,19.845715,41.724836",
     "geom:latitude":41.630264,
     "geom:longitude":19.714448,
@@ -232,16 +232,21 @@
         "gn:id":3315070,
         "gp:id":20069935,
         "hasc:id":"AL.LZ.KB",
+        "iso:code_historic":"AL-KB",
         "qs_pg:id":488618,
         "wd:id":"Q123602",
         "wk:page":"Kurbin District"
     },
+    "wof:concordances_official":"iso:code_historic",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"AL",
     "wof:created":1459009292,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"37506a26fea2e2b62047863f74b46735",
+    "wof:geomhash":"0adaef9a9f4c0737789f7b97a2c04a57",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -251,7 +256,7 @@
         }
     ],
     "wof:id":421181321,
-    "wof:lastmodified":1690849778,
+    "wof:lastmodified":1695886586,
     "wof:name":"Kurbin",
     "wof:parent_id":85667829,
     "wof:placetype":"county",

--- a/data/421/182/353/421182353.geojson
+++ b/data/421/182/353/421182353.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":557422,
     "eurostat:population_year":2019,
     "geom:area":0.118524,
-    "geom:area_square_m":1100934315.433672,
+    "geom:area_square_m":1100934517.940442,
     "geom:bbox":"19.588457,41.120346,20.233729,41.517134",
     "geom:latitude":41.305978,
     "geom:longitude":19.884289,
@@ -235,16 +235,21 @@
         "gn:id":3183879,
         "gp:id":20069963,
         "hasc:id":"AL.TI.TR",
+        "iso:code_historic":"AL-TR",
         "qs_pg:id":902456,
         "wd:id":"Q201073",
         "wk:page":"Tirana District"
     },
+    "wof:concordances_official":"iso:code_historic",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"AL",
     "wof:created":1459009327,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c7a06272cbf2ad943311b44e50e016b9",
+    "wof:geomhash":"10cef97c1e67597035e5ac298be2a74d",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -254,7 +259,7 @@
         }
     ],
     "wof:id":421182353,
-    "wof:lastmodified":1690849783,
+    "wof:lastmodified":1695886586,
     "wof:name":"Tiran\u00eb",
     "wof:parent_id":1108803089,
     "wof:placetype":"county",

--- a/data/421/184/327/421184327.geojson
+++ b/data/421/184/327/421184327.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":7887,
     "eurostat:population_year":2019,
     "geom:area":0.019318,
-    "geom:area_square_m":182989568.416722,
+    "geom:area_square_m":182989439.455634,
     "geom:bbox":"19.915207,39.913137,20.140541,40.072636",
     "geom:latitude":39.997746,
     "geom:longitude":20.031924,
@@ -235,16 +235,21 @@
         "gn:id":414383,
         "gp:id":20069960,
         "hasc:id":"AL.VR.DL",
+        "iso:code_historic":"AL-DL",
         "qs_pg:id":995361,
         "wd:id":"Q166959",
         "wk:page":"Delvin\u00eb District"
     },
+    "wof:concordances_official":"iso:code_historic",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"AL",
     "wof:created":1459009407,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"19653c25f81ecdc41cb5aac29ad0c0cc",
+    "wof:geomhash":"a9579309eb28a5b1cfcc8c2c9c15f85d",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -254,7 +259,7 @@
         }
     ],
     "wof:id":421184327,
-    "wof:lastmodified":1690849781,
+    "wof:lastmodified":1695886586,
     "wof:name":"Delvin\u00eb",
     "wof:parent_id":85667801,
     "wof:placetype":"county",

--- a/data/421/184/543/421184543.geojson
+++ b/data/421/184/543/421184543.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":83659,
     "eurostat:population_year":2019,
     "geom:area":0.0398,
-    "geom:area_square_m":371921477.849884,
+    "geom:area_square_m":371921399.964895,
     "geom:bbox":"19.58151,40.771677,19.847983,41.065738",
     "geom:latitude":40.909875,
     "geom:longitude":19.708116,
@@ -229,16 +229,21 @@
         "gn:id":3184864,
         "gp:id":20069947,
         "hasc:id":"AL.FI.LN",
+        "iso:code_historic":"AL-LU",
         "qs_pg:id":1001527,
         "wd:id":"Q206994",
         "wk:page":"Lushnj\u00eb District"
     },
+    "wof:concordances_official":"iso:code_historic",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"AL",
     "wof:created":1459009414,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bd6c5ad3349a2cbf7a3c0b585267d34b",
+    "wof:geomhash":"1e4ea6f33b6393ee6e9acaa2624ac9de",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -248,7 +253,7 @@
         }
     ],
     "wof:id":421184543,
-    "wof:lastmodified":1690849781,
+    "wof:lastmodified":1695886586,
     "wof:name":"Lushnje",
     "wof:parent_id":85667789,
     "wof:placetype":"county",

--- a/data/421/185/415/421185415.geojson
+++ b/data/421/185/415/421185415.geojson
@@ -251,16 +251,21 @@
         "gn:id":783265,
         "gp:id":20069949,
         "hasc:id":"AL.EB.EB",
+        "iso:code_historic":"AL-EL",
         "qs_pg:id":895196,
         "wd:id":"Q205247",
         "wk:page":"Elbasan District"
     },
+    "wof:concordances_official":"iso:code_historic",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"AL",
     "wof:created":1459009442,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"deeab1767105914317362cdc33ed3980",
+    "wof:geomhash":"5d1aaa1be3b79191de888c1f0829756a",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -270,7 +275,7 @@
         }
     ],
     "wof:id":421185415,
-    "wof:lastmodified":1690849784,
+    "wof:lastmodified":1695886586,
     "wof:name":"Elbasan",
     "wof:parent_id":85667815,
     "wof:placetype":"county",

--- a/data/421/186/339/421186339.geojson
+++ b/data/421/186/339/421186339.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":47985,
     "eurostat:population_year":2019,
     "geom:area":0.101219,
-    "geom:area_square_m":930159116.87495,
+    "geom:area_square_m":930159588.997459,
     "geom:bbox":"20.136639,41.815825,20.625484,42.181316",
     "geom:latitude":41.997019,
     "geom:longitude":20.400702,
@@ -271,16 +271,21 @@
         "gn:id":782662,
         "gp:id":20069931,
         "hasc:id":"AL.KK.KK",
+        "iso:code_historic":"AL-KU",
         "qs_pg:id":1064358,
         "wd:id":"Q123395",
         "wk:page":"Kuk\u00ebs District"
     },
+    "wof:concordances_official":"iso:code_historic",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"AL",
     "wof:created":1459009477,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"069084a08ddff4f0790c0b1090d1f835",
+    "wof:geomhash":"921778e4331fc3c63ae993828227b9c6",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -290,7 +295,7 @@
         }
     ],
     "wof:id":421186339,
-    "wof:lastmodified":1690849777,
+    "wof:lastmodified":1695886586,
     "wof:name":"Kuk\u00ebs",
     "wof:parent_id":85667797,
     "wof:placetype":"county",

--- a/data/421/187/431/421187431.geojson
+++ b/data/421/187/431/421187431.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":59814,
     "eurostat:population_year":2019,
     "geom:area":0.036694,
-    "geom:area_square_m":339816769.633955,
+    "geom:area_square_m":339816723.983678,
     "geom:bbox":"19.583901,41.399927,19.911287,41.590286",
     "geom:latitude":41.501798,
     "geom:longitude":19.747757,
@@ -257,15 +257,20 @@
         "gn:id":3185084,
         "gp:id":20069936,
         "hasc:id":"AL.DU.KE",
+        "iso:code_historic":"AL-KR",
         "qs_pg:id":1083105,
         "wd:id":"Q205261"
     },
+    "wof:concordances_official":"iso:code_historic",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"AL",
     "wof:created":1459009513,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c3516ddcc858fe8cda0834841560dd04",
+    "wof:geomhash":"51e144c55e3495d4a7d36c5ae87cce49",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -275,7 +280,7 @@
         }
     ],
     "wof:id":421187431,
-    "wof:lastmodified":1690849773,
+    "wof:lastmodified":1695886587,
     "wof:name":"Kruj\u00eb",
     "wof:parent_id":85667783,
     "wof:placetype":"county",

--- a/data/421/187/433/421187433.geojson
+++ b/data/421/187/433/421187433.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":175110,
     "eurostat:population_year":2019,
     "geom:area":0.036784,
-    "geom:area_square_m":341052166.696103,
+    "geom:area_square_m":341052264.913668,
     "geom:bbox":"19.391277,41.251731,19.622862,41.588749",
     "geom:latitude":41.423889,
     "geom:longitude":19.526308,
@@ -277,16 +277,21 @@
         "gn:id":3185730,
         "gp:id":20069937,
         "hasc:id":"AL.DU.DR",
+        "iso:code_historic":"AL-DR",
         "qs_pg:id":1083106,
         "wd:id":"Q37662",
         "wk:page":"Durr\u00ebs District"
     },
+    "wof:concordances_official":"iso:code_historic",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"AL",
     "wof:created":1459009513,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"59ba4ec3a1bd569ef456ebe10271a298",
+    "wof:geomhash":"edd4045021add40169b60f71c651db47",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -296,7 +301,7 @@
         }
     ],
     "wof:id":421187433,
-    "wof:lastmodified":1690849775,
+    "wof:lastmodified":1695886587,
     "wof:name":"Durr\u00ebs",
     "wof:parent_id":85667783,
     "wof:placetype":"county",

--- a/data/421/187/447/421187447.geojson
+++ b/data/421/187/447/421187447.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":40094,
     "eurostat:population_year":2019,
     "geom:area":0.021509,
-    "geom:area_square_m":200162433.688862,
+    "geom:area_square_m":200162290.013348,
     "geom:bbox":"19.436251,41.097795,19.700263,41.270223",
     "geom:latitude":41.184712,
     "geom:longitude":19.566439,
@@ -241,16 +241,21 @@
         "gn:id":3315068,
         "gp:id":20069942,
         "hasc:id":"AL.TI.KA",
+        "iso:code_historic":"AL-KA",
         "qs_pg:id":1083481,
         "wd:id":"Q194182",
         "wk:page":"Kavaj\u00eb District"
     },
+    "wof:concordances_official":"iso:code_historic",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"AL",
     "wof:created":1459009513,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4e54b479bceca7f418f5bb7a4c43e981",
+    "wof:geomhash":"19b8d8f8463dcfeb92351a0999ed7148",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -260,7 +265,7 @@
         }
     ],
     "wof:id":421187447,
-    "wof:lastmodified":1690849770,
+    "wof:lastmodified":1695886587,
     "wof:name":"Kavaj\u00eb",
     "wof:parent_id":1108803089,
     "wof:placetype":"county",

--- a/data/421/187/685/421187685.geojson
+++ b/data/421/187/685/421187685.geojson
@@ -250,16 +250,21 @@
         "gn:id":783626,
         "gp:id":20069953,
         "hasc:id":"AL.BE.BR",
+        "iso:code_historic":"AL-BR",
         "qs_pg:id":1084260,
         "wd:id":"Q202981",
         "wk:page":"Berat District"
     },
+    "wof:concordances_official":"iso:code_historic",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"AL",
     "wof:created":1459009521,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7e1f1a685e84a747e1fca808cbce45a2",
+    "wof:geomhash":"bda47cd830f29828cffce2ca534589fa",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -269,7 +274,7 @@
         }
     ],
     "wof:id":421187685,
-    "wof:lastmodified":1690849774,
+    "wof:lastmodified":1695886587,
     "wof:name":"Berat",
     "wof:parent_id":85667811,
     "wof:placetype":"county",

--- a/data/421/187/687/421187687.geojson
+++ b/data/421/187/687/421187687.geojson
@@ -238,16 +238,21 @@
         "gn:id":3185674,
         "gp:id":20069955,
         "hasc:id":"AL.FI.FR",
+        "iso:code_historic":"AL-FR",
         "qs_pg:id":1084294,
         "wd:id":"Q209019",
         "wk:page":"Fier District"
     },
+    "wof:concordances_official":"iso:code_historic",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"AL",
     "wof:created":1459009521,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"51a2f3269a4112cc9510b1b0a9c797b7",
+    "wof:geomhash":"fb3c5cb65f3d3d2c4e02d492271773ee",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -257,7 +262,7 @@
         }
     ],
     "wof:id":421187687,
-    "wof:lastmodified":1690849772,
+    "wof:lastmodified":1695886587,
     "wof:name":"Fier",
     "wof:parent_id":85667789,
     "wof:placetype":"county",

--- a/data/421/187/729/421187729.geojson
+++ b/data/421/187/729/421187729.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":28673,
     "eurostat:population_year":2019,
     "geom:area":0.049557,
-    "geom:area_square_m":468529570.083624,
+    "geom:area_square_m":468529513.560507,
     "geom:bbox":"19.887916,40.005093,20.242138,40.230647",
     "geom:latitude":40.128984,
     "geom:longitude":20.072653,
@@ -235,16 +235,21 @@
         "gn:id":783151,
         "gp:id":20069959,
         "hasc:id":"AL.GK.GK",
+        "iso:code_historic":"AL-GJ",
         "qs_pg:id":1085620,
         "wd:id":"Q209749",
         "wk:page":"Gjirokast\u00ebr District"
     },
+    "wof:concordances_official":"iso:code_historic",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"AL",
     "wof:created":1459009522,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e158c8b0698dfabd0f2b3c9b8e5036d4",
+    "wof:geomhash":"c7a3edfdc6b5b2b67e7e4d3265f31ab3",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -254,7 +259,7 @@
         }
     ],
     "wof:id":421187729,
-    "wof:lastmodified":1690849776,
+    "wof:lastmodified":1695886587,
     "wof:name":"Gjirokast\u00ebr",
     "wof:parent_id":85667819,
     "wof:placetype":"county",

--- a/data/421/188/337/421188337.geojson
+++ b/data/421/188/337/421188337.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":22103,
     "eurostat:population_year":2019,
     "geom:area":0.09413,
-    "geom:area_square_m":867191168.829579,
+    "geom:area_square_m":867191141.721226,
     "geom:bbox":"19.71745,41.688013,20.275917,42.025033",
     "geom:latitude":41.836657,
     "geom:longitude":19.995238,
@@ -238,16 +238,21 @@
         "gn:id":782268,
         "gp:id":20069934,
         "hasc:id":"AL.LZ.MR",
+        "iso:code_historic":"AL-MR",
         "qs_pg:id":19029,
         "wd:id":"Q236850",
         "wk:page":"Mirdit\u00eb District"
     },
+    "wof:concordances_official":"iso:code_historic",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"AL",
     "wof:created":1459009542,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"afb8e37776196f08f33aa9ceb5b6dba9",
+    "wof:geomhash":"9454726262a2158bbc9c6bf4be28f447",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -257,7 +262,7 @@
         }
     ],
     "wof:id":421188337,
-    "wof:lastmodified":1690849776,
+    "wof:lastmodified":1695886587,
     "wof:name":"Mirdit\u00eb",
     "wof:parent_id":85667829,
     "wof:placetype":"county",

--- a/data/421/189/559/421189559.geojson
+++ b/data/421/189/559/421189559.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":8949,
     "eurostat:population_year":2019,
     "geom:area":0.0457,
-    "geom:area_square_m":431061425.070504,
+    "geom:area_square_m":431061250.441034,
     "geom:bbox":"19.747156,40.178785,20.155581,40.394393",
     "geom:latitude":40.286933,
     "geom:longitude":19.947234,
@@ -232,16 +232,21 @@
         "gn:id":3183911,
         "gp:id":20069957,
         "hasc:id":"AL.GK.TL",
+        "iso:code_historic":"AL-TE",
         "qs_pg:id":48942,
         "wd:id":"Q202656",
         "wk:page":"Tepelen\u00eb District"
     },
+    "wof:concordances_official":"iso:code_historic",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"AL",
     "wof:created":1459009628,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4c5b984e1acb8a2bb107f4b42e4f9f09",
+    "wof:geomhash":"7a00bd806c53f819992bd4263de9bd6a",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -251,7 +256,7 @@
         }
     ],
     "wof:id":421189559,
-    "wof:lastmodified":1690849776,
+    "wof:lastmodified":1695886587,
     "wof:name":"Tepelen\u00eb",
     "wof:parent_id":85667819,
     "wof:placetype":"county",

--- a/data/421/190/783/421190783.geojson
+++ b/data/421/190/783/421190783.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":75994,
     "eurostat:population_year":2019,
     "geom:area":0.085644,
-    "geom:area_square_m":804331712.176599,
+    "geom:area_square_m":804331989.657409,
     "geom:bbox":"20.400407,40.429509,20.865943,40.718642",
     "geom:latitude":40.578264,
     "geom:longitude":20.626208,
@@ -255,15 +255,20 @@
         "eurostat:nuts_2021_id":"AL343",
         "gp:id":20069945,
         "hasc:id":"AL.KE.KR",
+        "iso:code_historic":"AL-KO",
         "qs_pg:id":1120727,
         "wd:id":"Q191491"
     },
+    "wof:concordances_official":"iso:code_historic",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"AL",
     "wof:created":1459009669,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"936000401080e16c6ce92f60be6152f4",
+    "wof:geomhash":"c41ddc7421aace7a21175a0f97305ef2",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -273,7 +278,7 @@
         }
     ],
     "wof:id":421190783,
-    "wof:lastmodified":1690849779,
+    "wof:lastmodified":1695886588,
     "wof:name":"Kor\u00e7\u00eb",
     "wof:parent_id":85667807,
     "wof:placetype":"county",

--- a/data/421/190/851/421190851.geojson
+++ b/data/421/190/851/421190851.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":31210,
     "eurostat:population_year":2019,
     "geom:area":0.073389,
-    "geom:area_square_m":680029799.136821,
+    "geom:area_square_m":680029822.930485,
     "geom:bbox":"20.118701,41.315825,20.561153,41.619003",
     "geom:latitude":41.464491,
     "geom:longitude":20.342146,
@@ -250,16 +250,21 @@
         "gn:id":831275,
         "gp:id":20069939,
         "hasc:id":"AL.DB.BU",
+        "iso:code_historic":"AL-BU",
         "qs_pg:id":56313,
         "wd:id":"Q191872",
         "wk:page":"Bulqiz\u00eb District"
     },
+    "wof:concordances_official":"iso:code_historic",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"AL",
     "wof:created":1459009671,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4cb2b095ab4fe27fcdb5773bbdc5cf70",
+    "wof:geomhash":"e88bb465a0c3009e765c318bdd6043ba",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -269,7 +274,7 @@
         }
     ],
     "wof:id":421190851,
-    "wof:lastmodified":1690849779,
+    "wof:lastmodified":1695886588,
     "wof:name":"Bulqiz\u00eb",
     "wof:parent_id":85667821,
     "wof:placetype":"county",

--- a/data/421/191/637/421191637.geojson
+++ b/data/421/191/637/421191637.geojson
@@ -230,16 +230,21 @@
         "gn:id":783060,
         "gp:id":20069950,
         "hasc:id":"AL.EB.GH",
+        "iso:code_historic":"AL-GR",
         "qs_pg:id":1149771,
         "wd:id":"Q210090",
         "wk:page":"Gramsh District"
     },
+    "wof:concordances_official":"iso:code_historic",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"AL",
     "wof:created":1459009699,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ab6ba6c6c2fe3bc521a861c0422fcc88",
+    "wof:geomhash":"fbced2613753f6c1248f5467042ffaa2",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -249,7 +254,7 @@
         }
     ],
     "wof:id":421191637,
-    "wof:lastmodified":1690849779,
+    "wof:lastmodified":1695886588,
     "wof:name":"Gramsh",
     "wof:parent_id":85667815,
     "wof:placetype":"county",

--- a/data/421/192/831/421192831.geojson
+++ b/data/421/192/831/421192831.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":10614,
     "eurostat:population_year":2019,
     "geom:area":0.063716,
-    "geom:area_square_m":601317262.896243,
+    "geom:area_square_m":601317259.763821,
     "geom:bbox":"20.207514,40.06349,20.612034,40.441307",
     "geom:latitude":40.250108,
     "geom:longitude":20.405744,
@@ -232,16 +232,21 @@
         "gn:id":782072,
         "gp:id":20069956,
         "hasc:id":"AL.GK.PE",
+        "iso:code_historic":"AL-PR",
         "qs_pg:id":1176347,
         "wd:id":"Q121074",
         "wk:page":"P\u00ebrmet District"
     },
+    "wof:concordances_official":"iso:code_historic",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"AL",
     "wof:created":1459009750,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1ae30cda1054a520aede04990ff80ce1",
+    "wof:geomhash":"c44fc3dc91b0cbcb82e85911ea5ae254",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -251,7 +256,7 @@
         }
     ],
     "wof:id":421192831,
-    "wof:lastmodified":1690849766,
+    "wof:lastmodified":1695886588,
     "wof:name":"P\u00ebrmet",
     "wof:parent_id":85667819,
     "wof:placetype":"county",

--- a/data/421/193/315/421193315.geojson
+++ b/data/421/193/315/421193315.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":11069,
     "eurostat:population_year":2019,
     "geom:area":0.055007,
-    "geom:area_square_m":505361304.013614,
+    "geom:area_square_m":505361145.609212,
     "geom:bbox":"19.718856,41.874073,20.088477,42.149202",
     "geom:latitude":42.012679,
     "geom:longitude":19.912001,
@@ -235,16 +235,21 @@
         "gn:id":781913,
         "gp:id":20069932,
         "hasc:id":"AL.SD.PU",
+        "iso:code_historic":"AL-PU",
         "qs_pg:id":887465,
         "wd:id":"Q206997",
         "wk:page":"Puk\u00eb District"
     },
+    "wof:concordances_official":"iso:code_historic",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"AL",
     "wof:created":1459009767,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a88c924449c5b26fac43e09e86bfb209",
+    "wof:geomhash":"790f873f150ec2e628293ccc5272c93a",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -254,7 +259,7 @@
         }
     ],
     "wof:id":421193315,
-    "wof:lastmodified":1690849768,
+    "wof:lastmodified":1695886588,
     "wof:name":"Puk\u00eb",
     "wof:parent_id":85667793,
     "wof:placetype":"county",

--- a/data/421/193/353/421193353.geojson
+++ b/data/421/193/353/421193353.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":104827,
     "eurostat:population_year":2019,
     "geom:area":0.065827,
-    "geom:area_square_m":619736141.764387,
+    "geom:area_square_m":619736066.899068,
     "geom:bbox":"19.262861,40.171138,19.619308,40.664711",
     "geom:latitude":40.414173,
     "geom:longitude":19.474202,
@@ -244,16 +244,21 @@
         "gn:id":3183721,
         "gp:id":20069958,
         "hasc:id":"AL.VR.VL",
+        "iso:code_historic":"AL-VL",
         "qs_pg:id":890117,
         "wd:id":"Q158601",
         "wk:page":"Vlor\u00eb District"
     },
+    "wof:concordances_official":"iso:code_historic",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"AL",
     "wof:created":1459009768,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"79f1de0219c2660900315cd1728d57e8",
+    "wof:geomhash":"ce69e30b21988a8021f40a5dd7aecb3e",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -263,7 +268,7 @@
         }
     ],
     "wof:id":421193353,
-    "wof:lastmodified":1690849767,
+    "wof:lastmodified":1695886588,
     "wof:name":"Vlor\u00eb",
     "wof:parent_id":85667801,
     "wof:placetype":"county",

--- a/data/421/193/597/421193597.geojson
+++ b/data/421/193/597/421193597.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":11070,
     "eurostat:population_year":2019,
     "geom:area":0.091518,
-    "geom:area_square_m":862862520.40519,
+    "geom:area_square_m":862862501.05373,
     "geom:bbox":"20.442304,40.079351,20.792649,40.499187",
     "geom:latitude":40.315489,
     "geom:longitude":20.620329,
@@ -228,15 +228,20 @@
         "eurostat:nuts_2021_id":"AL342",
         "gp:id":20069946,
         "hasc:id":"AL.KE.KJ",
+        "iso:code_historic":"AL-ER",
         "qs_pg:id":66022,
         "wd:id":"Q194178"
     },
+    "wof:concordances_official":"iso:code_historic",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"AL",
     "wof:created":1459009776,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e1f98750d8f73122ef36f6e2f0204e66",
+    "wof:geomhash":"eea718e817312bf34024b7c3682132c0",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -246,7 +251,7 @@
         }
     ],
     "wof:id":421193597,
-    "wof:lastmodified":1690849768,
+    "wof:lastmodified":1695886588,
     "wof:name":"Kolonj\u00eb",
     "wof:parent_id":85667807,
     "wof:placetype":"county",

--- a/data/421/194/959/421194959.geojson
+++ b/data/421/194/959/421194959.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":12403,
     "eurostat:population_year":2019,
     "geom:area":0.088318,
-    "geom:area_square_m":829735360.46143,
+    "geom:area_square_m":829735608.232924,
     "geom:bbox":"20.065377,40.361876,20.443,40.748024",
     "geom:latitude":40.554647,
     "geom:longitude":20.262583,
@@ -241,16 +241,21 @@
         "gn:id":781574,
         "gp:id":20069951,
         "hasc:id":"AL.BE.SK",
+        "iso:code_historic":"AL-SK",
         "qs_pg:id":62694,
         "wd:id":"Q194381",
         "wk:page":"Skrapar District"
     },
+    "wof:concordances_official":"iso:code_historic",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"AL",
     "wof:created":1459009826,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"01fbbef5578a654bdf61c6c258004b34",
+    "wof:geomhash":"954689df88e3dedc0bb411ebbe811022",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -260,7 +265,7 @@
         }
     ],
     "wof:id":421194959,
-    "wof:lastmodified":1690849767,
+    "wof:lastmodified":1695886590,
     "wof:name":"Skrapar",
     "wof:parent_id":85667811,
     "wof:placetype":"county",

--- a/data/421/199/463/421199463.geojson
+++ b/data/421/199/463/421199463.geojson
@@ -226,16 +226,21 @@
         "gn:id":782521,
         "gp:id":20069941,
         "hasc:id":"AL.EB.LB",
+        "iso:code_historic":"AL-LB",
         "qs_pg:id":478505,
         "wd:id":"Q207002",
         "wk:page":"Librazhd District"
     },
+    "wof:concordances_official":"iso:code_historic",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"AL",
     "wof:created":1459009990,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d36332a9b7cfd7f28104b8727e378bb1",
+    "wof:geomhash":"9e3d5d8306de5a1db3fcb990573526d7",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -245,7 +250,7 @@
         }
     ],
     "wof:id":421199463,
-    "wof:lastmodified":1690849780,
+    "wof:lastmodified":1695886590,
     "wof:name":"Librazhd",
     "wof:parent_id":85667815,
     "wof:placetype":"county",

--- a/data/421/200/781/421200781.geojson
+++ b/data/421/200/781/421200781.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":20517,
     "eurostat:population_year":2019,
     "geom:area":0.115351,
-    "geom:area_square_m":1053780535.398396,
+    "geom:area_square_m":1053781455.101111,
     "geom:bbox":"19.800354,42.195869,20.361814,42.559257",
     "geom:latitude":42.370674,
     "geom:longitude":20.048948,
@@ -235,16 +235,21 @@
         "gn:id":781360,
         "gp:id":20069929,
         "hasc:id":"AL.KK.TP",
+        "iso:code_historic":"AL-TP",
         "qs_pg:id":894540,
         "wd:id":"Q123615",
         "wk:page":"Tropoj\u00eb District"
     },
+    "wof:concordances_official":"iso:code_historic",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"AL",
     "wof:created":1459010041,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"20b17b8f0586daa6a34d194bd6e498e7",
+    "wof:geomhash":"e98ae64f690419f3c1474c13970f6e9c",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -254,7 +259,7 @@
         }
     ],
     "wof:id":421200781,
-    "wof:lastmodified":1690849780,
+    "wof:lastmodified":1695886590,
     "wof:name":"Tropoj\u00eb",
     "wof:parent_id":85667797,
     "wof:placetype":"county",

--- a/data/421/202/751/421202751.geojson
+++ b/data/421/202/751/421202751.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":27600,
     "eurostat:population_year":2019,
     "geom:area":0.053428,
-    "geom:area_square_m":493713770.394613,
+    "geom:area_square_m":493713957.866986,
     "geom:bbox":"19.806707,41.516231,20.194132,41.766671",
     "geom:latitude":41.641267,
     "geom:longitude":19.997406,
@@ -223,16 +223,21 @@
         "gn:id":782345,
         "gp:id":20069940,
         "hasc:id":"AL.DB.MA",
+        "iso:code_historic":"AL-MT",
         "qs_pg:id":41353,
         "wd:id":"Q202665",
         "wk:page":"Mat District"
     },
+    "wof:concordances_official":"iso:code_historic",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"AL",
     "wof:created":1459010128,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d7263b0660244b4b61b81d094b4828c6",
+    "wof:geomhash":"d08de013b40b121414998f1c6778ad85",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -242,7 +247,7 @@
         }
     ],
     "wof:id":421202751,
-    "wof:lastmodified":1690849770,
+    "wof:lastmodified":1695886591,
     "wof:name":"Mat",
     "wof:parent_id":85667821,
     "wof:placetype":"county",

--- a/data/856/324/05/85632405.geojson
+++ b/data/856/324/05/85632405.geojson
@@ -1245,6 +1245,7 @@
         "hasc:id":"AL",
         "icao:code":"ZA",
         "ioc:id":"ALB",
+        "iso:code":"AL",
         "itu:id":"ALB",
         "loc:id":"n83221467",
         "m49:code":"008",
@@ -1259,6 +1260,7 @@
         "wk:page":"Albania",
         "wmo:id":"AB"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AL",
     "wof:country_alpha3":"ALB",
     "wof:geom_alt":[
@@ -1280,7 +1282,7 @@
     "wof:lang_x_spoken":[
         "sqi"
     ],
-    "wof:lastmodified":1694492247,
+    "wof:lastmodified":1695881359,
     "wof:name":"Albania",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/856/677/83/85667783.geojson
+++ b/data/856/677/83/85667783.geojson
@@ -19,7 +19,7 @@
     "eurostat:population_year":2021,
     "eurostat:urban_type":"2",
     "geom:area":0.083405,
-    "geom:area_square_m":773022402.543181,
+    "geom:area_square_m":773022635.43257,
     "geom:bbox":"19.391277,41.251731,19.911287,41.590286",
     "geom:latitude":41.448447,
     "geom:longitude":19.630776,
@@ -387,16 +387,18 @@
         "gn:id":3344947,
         "gp:id":29389556,
         "hasc:id":"AL.DU",
+        "iso:code":"AL-02",
         "iso:id":"AL-02",
         "qs_pg:id":898962,
         "wd:id":"Q192853",
         "wk:page":"Durr\u00ebs County"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1bcd22a03e12c99040c0011b814e2ebb",
+    "wof:geomhash":"8092cad2a02ed08285d433560f7f88bf",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -411,7 +413,7 @@
     "wof:lang_x_spoken":[
         "sqi"
     ],
-    "wof:lastmodified":1690849762,
+    "wof:lastmodified":1695885189,
     "wof:name":"Durr\u00ebs",
     "wof:parent_id":85632405,
     "wof:placetype":"region",

--- a/data/856/677/89/85667789.geojson
+++ b/data/856/677/89/85667789.geojson
@@ -343,17 +343,19 @@
         "gn:id":3344948,
         "gp:id":29389558,
         "hasc:id":"AL.FI",
+        "iso:code":"AL-04",
         "iso:id":"AL-04",
         "qs_pg:id":359526,
         "unlc:id":"AL-FR",
         "wd:id":"Q231900",
         "wk:page":"Fier County"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ed59cfdf3ab29156d05a9a8a8caf7676",
+    "wof:geomhash":"80bcd2183f4e0fb9053b6c72f324815d",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -368,7 +370,7 @@
     "wof:lang_x_spoken":[
         "sqi"
     ],
-    "wof:lastmodified":1690849761,
+    "wof:lastmodified":1695885189,
     "wof:name":"Fier",
     "wof:parent_id":85632405,
     "wof:placetype":"region",

--- a/data/856/677/93/85667793.geojson
+++ b/data/856/677/93/85667793.geojson
@@ -341,16 +341,18 @@
         "gn:id":3344950,
         "gp:id":29389563,
         "hasc:id":"AL.SD",
+        "iso:code":"AL-10",
         "qs_pg:id":224191,
         "unlc:id":"AL-SH",
         "wd:id":"Q193438",
         "wk:page":"Shkod\u00ebr County"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"37a188bdecce6c071023dd82f1bfc6f4",
+    "wof:geomhash":"d3e02fead341d7df6a226bc42b5c9349",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -365,7 +367,7 @@
     "wof:lang_x_spoken":[
         "sqi"
     ],
-    "wof:lastmodified":1690849761,
+    "wof:lastmodified":1695885189,
     "wof:name":"Shkoder",
     "wof:parent_id":85632405,
     "wof:placetype":"region",

--- a/data/856/677/97/85667797.geojson
+++ b/data/856/677/97/85667797.geojson
@@ -19,7 +19,7 @@
     "eurostat:population_year":2021,
     "eurostat:urban_type":"3",
     "geom:area":0.260326,
-    "geom:area_square_m":2384783528.572192,
+    "geom:area_square_m":2384785271.353584,
     "geom:bbox":"19.800354,41.815825,20.625484,42.559257",
     "geom:latitude":42.195849,
     "geom:longitude":20.242174,
@@ -340,17 +340,19 @@
         "gn:id":865735,
         "gp:id":29389561,
         "hasc:id":"AL.KK",
+        "iso:code":"AL-07",
         "iso:id":"AL-07",
         "qs_pg:id":1198467,
         "unlc:id":"AL-KU",
         "wd:id":"Q231896",
         "wk:page":"Kuk\u00ebs County"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fd59be0b3badbe42c746adb2cc18c7dc",
+    "wof:geomhash":"2c5bd7fafef243fc87bf9258a9f52a52",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -365,7 +367,7 @@
     "wof:lang_x_spoken":[
         "sqi"
     ],
-    "wof:lastmodified":1690849762,
+    "wof:lastmodified":1695885189,
     "wof:name":"Kuk\u00ebs",
     "wof:parent_id":85632405,
     "wof:placetype":"region",

--- a/data/856/678/01/85667801.geojson
+++ b/data/856/678/01/85667801.geojson
@@ -19,7 +19,7 @@
     "eurostat:population_year":2021,
     "eurostat:urban_type":"3",
     "geom:area":0.283719,
-    "geom:area_square_m":2681411027.918199,
+    "geom:area_square_m":2681411199.175736,
     "geom:bbox":"19.262861,39.644482,20.322116,40.664711",
     "geom:latitude":40.152893,
     "geom:longitude":19.805076,
@@ -375,17 +375,19 @@
         "gn:id":3344952,
         "gp:id":29389565,
         "hasc:id":"AL.VR",
+        "iso:code":"AL-12",
         "iso:id":"AL-12",
         "qs_pg:id":499587,
         "unlc:id":"AL-VL",
         "wd:id":"Q192849",
         "wk:page":"Vlor\u00eb County"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"aa7af92234169ce0b637315447f52383",
+    "wof:geomhash":"f7656e9f3375a5f6435fbef16b547711",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -400,7 +402,7 @@
     "wof:lang_x_spoken":[
         "sqi"
     ],
-    "wof:lastmodified":1690849760,
+    "wof:lastmodified":1695885189,
     "wof:name":"Vlor\u00eb",
     "wof:parent_id":85632405,
     "wof:placetype":"region",

--- a/data/856/678/07/85667807.geojson
+++ b/data/856/678/07/85667807.geojson
@@ -19,7 +19,7 @@
     "eurostat:population_year":2021,
     "eurostat:urban_type":"3",
     "geom:area":0.397103,
-    "geom:area_square_m":3726543803.134348,
+    "geom:area_square_m":3726543763.668295,
     "geom:bbox":"20.296501,40.079351,21.057282,41.09164",
     "geom:latitude":40.629473,
     "geom:longitude":20.67074,
@@ -375,16 +375,18 @@
         "gn:id":865734,
         "gp:id":29389560,
         "hasc:id":"AL.KE",
+        "iso:code":"AL-06",
         "iso:id":"AL-06",
         "qs_pg:id":1316204,
         "unlc:id":"AL-KO",
         "wd:id":"Q193464"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"67b430633fcca39a93ff8deaf0da9a76",
+    "wof:geomhash":"c3183773d3d2cc3f214a5de6fc020954",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -399,7 +401,7 @@
     "wof:lang_x_spoken":[
         "sqi"
     ],
-    "wof:lastmodified":1690849760,
+    "wof:lastmodified":1695885189,
     "wof:name":"Kor\u00e7\u00eb",
     "wof:parent_id":85632405,
     "wof:placetype":"region",

--- a/data/856/678/11/85667811.geojson
+++ b/data/856/678/11/85667811.geojson
@@ -388,17 +388,19 @@
         "gn:id":865730,
         "gp:id":29389554,
         "hasc:id":"AL.BE",
+        "iso:code":"AL-01",
         "iso:id":"AL-01",
         "qs_pg:id":898961,
         "unlc:id":"AL-BR",
         "wd:id":"Q189296",
         "wk:page":"Berat County"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"161eb3e8fd9b3186b08433985b7431e1",
+    "wof:geomhash":"6176f2f1a73c930950777e2d6391a636",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -413,7 +415,7 @@
     "wof:lang_x_spoken":[
         "sqi"
     ],
-    "wof:lastmodified":1690849759,
+    "wof:lastmodified":1695885189,
     "wof:name":"Berat",
     "wof:parent_id":85632405,
     "wof:placetype":"region",

--- a/data/856/678/15/85667815.geojson
+++ b/data/856/678/15/85667815.geojson
@@ -355,17 +355,19 @@
         "gn:id":865732,
         "gp:id":29389557,
         "hasc:id":"AL.EB",
+        "iso:code":"AL-03",
         "iso:id":"AL-03",
         "qs_pg:id":898963,
         "unlc:id":"AL-EL",
         "wd:id":"Q193790",
         "wk:page":"Elbasan County"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fd2ca06ac564bbaa8f844ac70fce150f",
+    "wof:geomhash":"988c997bf0b07f56f342c6bde1e431c8",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -380,7 +382,7 @@
     "wof:lang_x_spoken":[
         "sqi"
     ],
-    "wof:lastmodified":1690849761,
+    "wof:lastmodified":1695885189,
     "wof:name":"Elbasan",
     "wof:parent_id":85632405,
     "wof:placetype":"region",

--- a/data/856/678/19/85667819.geojson
+++ b/data/856/678/19/85667819.geojson
@@ -386,17 +386,19 @@
         "gn:id":865733,
         "gp:id":29389559,
         "hasc:id":"AL.GK",
+        "iso:code":"AL-05",
         "iso:id":"AL-05",
         "qs_pg:id":359527,
         "unlc:id":"AL-GJ",
         "wd:id":"Q193454",
         "wk:page":"Gjirokast\u00ebr County"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fcd743edef4a8238dc63c9544e91231f",
+    "wof:geomhash":"acd73923b02b325b75308ec002019997",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -411,7 +413,7 @@
     "wof:lang_x_spoken":[
         "sqi"
     ],
-    "wof:lastmodified":1690849759,
+    "wof:lastmodified":1695885189,
     "wof:name":"Gjirokaste",
     "wof:parent_id":85632405,
     "wof:placetype":"region",

--- a/data/856/678/21/85667821.geojson
+++ b/data/856/678/21/85667821.geojson
@@ -19,7 +19,7 @@
     "eurostat:population_year":2021,
     "eurostat:urban_type":"3",
     "geom:area":0.267079,
-    "geom:area_square_m":2469343818.960705,
+    "geom:area_square_m":2469343876.898618,
     "geom:bbox":"19.806707,41.315825,20.573702,41.907447",
     "geom:latitude":41.606223,
     "geom:longitude":20.239622,
@@ -350,17 +350,19 @@
         "gn:id":865731,
         "gp:id":29389555,
         "hasc:id":"AL.DB",
+        "iso:code":"AL-09",
         "iso:id":"AL-09",
         "qs_pg:id":1104082,
         "unlc:id":"AL-DI",
         "wd:id":"Q192866",
         "wk:page":"Dib\u00ebr County"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a93b4fa0fa3eee1e224e5fbebc7755fe",
+    "wof:geomhash":"4fa084f84135a6a80cacb21e5c8591a1",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -375,7 +377,7 @@
     "wof:lang_x_spoken":[
         "sqi"
     ],
-    "wof:lastmodified":1690849760,
+    "wof:lastmodified":1695885189,
     "wof:name":"Dib\u00ebr",
     "wof:parent_id":85632405,
     "wof:placetype":"region",

--- a/data/856/678/29/85667829.geojson
+++ b/data/856/678/29/85667829.geojson
@@ -19,7 +19,7 @@
     "eurostat:population_year":2021,
     "eurostat:urban_type":"3",
     "geom:area":0.179044,
-    "geom:area_square_m":1650397668.411143,
+    "geom:area_square_m":1650397769.84962,
     "geom:bbox":"19.462422,41.556874,20.275917,42.025033",
     "geom:latitude":41.800754,
     "geom:longitude":19.848352,
@@ -338,17 +338,19 @@
         "gn:id":3344949,
         "gp:id":29389562,
         "hasc:id":"AL.LZ",
+        "iso:code":"AL-08",
         "iso:id":"AL-08",
         "qs_pg:id":1198468,
         "unlc:id":"AL-LE",
         "wd:id":"Q193436",
         "wk:page":"Lezh\u00eb County"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"46550cb564e999552773da4db298053a",
+    "wof:geomhash":"eb3fa4586c78191de6a9a7a838c9b957",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -363,7 +365,7 @@
     "wof:lang_x_spoken":[
         "sqi"
     ],
-    "wof:lastmodified":1690849759,
+    "wof:lastmodified":1695885190,
     "wof:name":"Lezh\u00eb",
     "wof:parent_id":85632405,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.