### PR TITLE
[WIP] Deduplicate records, supersede, swap properties, concordances

### DIFF
--- a/data/127/690/527/1/1276905271.geojson
+++ b/data/127/690/527/1/1276905271.geojson
@@ -11,6 +11,7 @@
     "geom:longitude":19.63917,
     "gn:admin1_code":"49",
     "gn:asciiname":"Ducaj",
+    "gn:cc2":"AL",
     "gn:country_code":"AL",
     "gn:dem":754,
     "gn:feature_class":"P",
@@ -29,6 +30,10 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:und_x_variant":[
+        "Ducej",
+        "Ducaj"
+    ],
     "src:geom":"geonames",
     "wof:belongsto":[
         102191581,
@@ -39,6 +44,11 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":3343620
+    },
+    "wof:concordances_alt":{
+        "gn:id":[
+            3185747
+        ]
     },
     "wof:country":"AL",
     "wof:geomhash":"b8c07e00bb9eeaef0f8e0d94f7c0a13e",
@@ -52,13 +62,15 @@
         }
     ],
     "wof:id":1276905271,
-    "wof:lastmodified":1566584780,
+    "wof:lastmodified":1706219587,
     "wof:name":"Ducaj",
     "wof:parent_id":1108720883,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-al",
     "wof:superseded_by":[],
-    "wof:supersedes":[],
+    "wof:supersedes":[
+        1343696505
+    ],
     "wof:tags":[]
 },
   "bbox": [

--- a/data/129/352/438/9/1293524389.geojson
+++ b/data/129/352/438/9/1293524389.geojson
@@ -30,7 +30,34 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:ceb_x_preferred":[
+        "Krast\u00eb"
+    ],
+    "name:deu_x_preferred":[
+        "Krasta"
+    ],
+    "name:mkd_x_preferred":[
+        "\u041a\u0440\u0430\u0441\u0442\u0430"
+    ],
+    "name:ron_x_preferred":[
+        "Krasta"
+    ],
     "name:rus_x_preferred":[
+        "\u041a\u0440\u0430\u0441\u0442\u0430"
+    ],
+    "name:spa_x_preferred":[
+        "Kraste"
+    ],
+    "name:sqi_x_preferred":[
+        "Krasta"
+    ],
+    "name:swe_x_preferred":[
+        "Krast\u00eb"
+    ],
+    "name:tur_x_preferred":[
+        "Krasta"
+    ],
+    "name:ukr_x_preferred":[
         "\u041a\u0440\u0430\u0441\u0442\u0430"
     ],
     "name:und_x_variant":[
@@ -46,7 +73,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "gn:id":864835
+        "gn:id":864835,
+        "wk:page":"Krast%C3%AB%2C_Dib%C3%ABr"
+    },
+    "wof:concordances_alt":{
+        "gn:id":[
+            782707
+        ]
     },
     "wof:country":"AL",
     "wof:geomhash":"ac757d3a306b4323d8a6412ed8c06433",
@@ -60,13 +93,15 @@
         }
     ],
     "wof:id":1293524389,
-    "wof:lastmodified":1566584704,
+    "wof:lastmodified":1706219587,
     "wof:name":"Kraste",
     "wof:parent_id":421190851,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-al",
     "wof:superseded_by":[],
-    "wof:supersedes":[],
+    "wof:supersedes":[
+        1327061559
+    ],
     "wof:tags":[]
 },
   "bbox": [

--- a/data/132/706/155/9/1327061559.geojson
+++ b/data/132/706/155/9/1327061559.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2024-01-19",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2024-01-19",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"20.205,41.42278,20.205,41.42278",
@@ -28,7 +30,7 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "name:ceb_x_preferred":[
         "Krast\u00eb"
@@ -84,12 +86,14 @@
         }
     ],
     "wof:id":1327061559,
-    "wof:lastmodified":1566584590,
+    "wof:lastmodified":1706219587,
     "wof:name":"Kraste",
     "wof:parent_id":421190851,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-al",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1293524389
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/134/369/650/5/1343696505.geojson
+++ b/data/134/369/650/5/1343696505.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2024-01-19",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2024-01-19",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"19.63722,42.3425,19.63722,42.3425",
@@ -28,7 +30,7 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "name:und_x_variant":[
         "Ducej",
@@ -46,7 +48,7 @@
         "gn:id":3185747
     },
     "wof:country":"AL",
-    "wof:geomhash":"3ec64fe4a01bd41c721b96bffc1b1de7",
+    "wof:geomhash":"a3919283e706074e68e64f6729c2c935",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -57,20 +59,22 @@
         }
     ],
     "wof:id":1343696505,
-    "wof:lastmodified":1566584674,
+    "wof:lastmodified":1706219586,
     "wof:name":"Ducaj",
     "wof:parent_id":1108720883,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-al",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1276905271
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },
   "bbox": [
-    19.63722000000001,
+    19.63722,
     42.3425,
-    19.63722000000001,
+    19.63722,
     42.3425
 ],
-  "geometry": {"coordinates":[19.63722000000001,42.3425],"type":"Point"}
+  "geometry": {"coordinates":[19.63722,42.3425],"type":"Point"}
 }

--- a/data/136/013/587/7/1360135877.geojson
+++ b/data/136/013/587/7/1360135877.geojson
@@ -46,6 +46,11 @@
     "wof:concordances":{
         "gn:id":3343856
     },
+    "wof:concordances_alt":{
+        "gn:id":[
+            3185577
+        ]
+    },
     "wof:country":"AL",
     "wof:geomhash":"ef5fc84c92f103a2be327a59921bb99f",
     "wof:hierarchy":[
@@ -58,13 +63,15 @@
         }
     ],
     "wof:id":1360135877,
-    "wof:lastmodified":1566584915,
+    "wof:lastmodified":1706219587,
     "wof:name":"Gjeroven",
     "wof:parent_id":421187685,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-al",
     "wof:superseded_by":[],
-    "wof:supersedes":[],
+    "wof:supersedes":[
+        1360223079
+    ],
     "wof:tags":[]
 },
   "bbox": [

--- a/data/136/022/307/9/1360223079.geojson
+++ b/data/136/022/307/9/1360223079.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2024-01-19",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2024-01-19",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"19.925,40.6675,19.925,40.6675",
@@ -28,7 +30,7 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "name:und_x_variant":[
         "Gjerovan",
@@ -62,12 +64,14 @@
         }
     ],
     "wof:id":1360223079,
-    "wof:lastmodified":1566584915,
+    "wof:lastmodified":1706219587,
     "wof:name":"Gjeroven",
     "wof:parent_id":421187685,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-al",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1360135877
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },


### PR DESCRIPTION
Round two... this PR updates duplicate records within WOF. When a duplicate pair/set is found:

- One record is superseded into the other
- Properties are transferred from the superseded record to the superseding record (if the property doesn't already exist)
- Concordances are transferred from the superseded record to the superseding record. If the concordance exists, a `wof:concordances_alt` property is used. If the concordance doesn't exist, it's added to the `wof:concordances` property

Duplicates were found by scoping a single placetype, checking for records with geometries near one another and identical (or nearly identical) names. Duplicate pairs were found the following way:

- If two point geometries: within 300m of one another
  - The older record of the two is kept, the newest is superseded
- If one point and one polygon: point is within the polygon OR point is within 300m of the polygon record's centroid
  - The record with the polygon is kept, the point is superseded
- If two polygon geometries: polygons overlap OR both records' centroids are within 300m of one another
  - The older record of the two is kept, the newest is superseded

Because this work is not scoped to a single repo, this work will also catch (many) cases where duplicates exist across two or more repos (one record in `whosonfirst-data-admin-xx` and `whosonfirst-data-admin-cr`, for example). I'm sure there are some edge cases that won't be caught with these parameters, but the duplicates I've reviewed have been legitimate. No PIP work needed - once this is approved, I'll open a few more PRs for review before running against all admin repos.